### PR TITLE
Add modal/recording systems and update docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); case \"$INPUT\" in *'\"stop_hook_active\":true'*) exit 0;; esac; cd \"$CLAUDE_PROJECT_DIR\" && OUT=$(just gate 2>&1) && exit 0; printf 'just gate FAILED:\\n%s\\n' \"$(printf '%s' \"$OUT\" | tail -50)\" >&2; exit 2",
+            "timeout": 600,
+            "statusMessage": "Running just gate (fmt · check · lint · test · doctest)…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Justfile
+++ b/Justfile
@@ -13,9 +13,10 @@ storybook:
 icons:
     cargo xtask icons
 
-# Build the docs + design-system book into ./book.
+# Build the docs + design-system book into ./book, then print a clickable link.
 book:
     mdbook build
+    @echo "Read: file://{{justfile_directory()}}/book/index.html"
 
 # Serve the book locally with live reload.
 book-serve:
@@ -36,8 +37,31 @@ web:
 dev:
     cd crates/arenic && trunk serve --public-url / index.html
 
+# Check formatting without touching files (CI-safe).
+fmt:
+    cargo fmt --all --check
+
+# Apply formatting.
+fmt-fix:
+    cargo fmt --all
+
+# Type-check everything (all targets, all features) without codegen.
+check:
+    cargo check --workspace --all-targets --all-features
+
+# Run the test suites (xtask, a dev tool, is excluded).
+test:
+    cargo test --workspace --exclude xtask
+
+# Compile + run every rustdoc example.
+doctest:
+    cargo test --workspace --doc
+
 # Lint the shipped crates (xtask, a dev tool, is excluded).
 lint:
     cargo clippy --workspace --exclude xtask --all-targets --all-features -- -D warnings
 
-gate: lint book
+# THE gate: everything must be green before a change is done. Runs after every
+# Claude Code turn (Stop hook in .claude/settings.json) and doubles as the
+# CI/CD gate. Ordered fast-fail: format → types → lints → tests → doctests.
+gate: fmt check lint test doctest

--- a/_docs/RULEBOOK.md
+++ b/_docs/RULEBOOK.md
@@ -23,16 +23,16 @@ Build a guild powerful enough to simultaneously manage 8 different arenas, each 
 ## Getting Started
 
 ### Your First Steps
-1. **Arena Selection**: Begin in Arena 1 with your starting hero
-2. **Movement**: Use WASD keys to move your hero one tile at a time on the grid
+1. **Arena Selection**: Begin in the Guild House (arena 1) with your starting hero
+2. **Movement**: Use the arrow keys to move your hero one tile at a time on the grid
 3. **Character Selection**: Press Tab to switch between available heroes in your current arena
-4. **Basic Combat**: Your hero will automatically attack nearby enemies based on their abilities
+4. **Basic Combat**: In combat arenas, your hero automatically attacks nearby enemies based on their abilities (the Guild House is a safe hearth with none)
 
 ### Understanding the Interface
 - **Grid-Based Movement**: Each arena is a 66×31 tile battlefield
 - **Multi-Arena View**: Access all 9 arenas through the navigation system
-- **Character Status**: Active characters are highlighted with blue materials
-- **Boss Visibility**: Enemy bosses appear as large red spheres in each arena
+- **Character Status**: The selected hero carries a glowing selection ring; ghosts carry a blue ring
+- **Boss Visibility**: Each combat arena holds one large themed relic boss with a glowing core (see Arena-Specific Boss Types); the Guild House has none
 
 ---
 
@@ -40,17 +40,30 @@ Build a guild powerful enough to simultaneously manage 8 different arenas, each 
 
 | Input | Action |
 |-------|--------|
-| **WASD** | Move active character (tile-by-tile grid movement) |
+| **Arrow Keys** | Move selected character (tile-by-tile grid movement) |
 | **Tab** | Switch to next character in current arena |
 | **Shift+Tab** | Switch to previous character in current arena |
 | **1-4** | Activate character abilities (when available) |
-| **R** | Start recording (character) / Show replay dialog (ghost with recording in arena) |
-| **F** | Finalize and commit the current recording |
+| **R** | Record key (context-sensitive): start the 3s countdown, or open a modal — *Record new / Replay previous / Cancel* (prior recording), *Record new / Cancel* (selected ghost), *Commit partial / Keep recording / Discard* (while recording) |
+| **[ / ]** | Cycle through arenas (0-8, wraps around) |
+| **P** | Toggle between single-arena view and all-arenas overview |
+| **Esc** | Cancel an open modal / return to the title screen |
 | **Enter** | Open guild house management menu |
-| **Q/E** | Rotate between different arena faces |
-| **W** | Zoom between arena view and overworld map |
-| **Mouse** | Arena selection and UI interaction |
-| **Space** | Interact with objects, chests, or confirm dialogues |
+| **Mouse** | Arena selection and UI interaction (optional — every modal is fully keyboard-driven) |
+| **Space** | Interact with objects and chests |
+
+### Modal Controls (keyboard-first)
+
+Every recording decision is a TUI-style modal driven entirely from the keyboard —
+think terminal permission prompts or Caves of Qud's dialogs. Mouse clicks work,
+but are never required:
+
+- Options lay out **horizontally** with numbered hotkeys — press **1-9** to choose one instantly
+- **← / →** (or **Tab / Shift+Tab**) move the focus highlight between options
+- **Enter** confirms the focused option; **Esc** always takes the safe/cancel option
+- A hint line on the modal spells out exactly these keys (`←→ focus · Enter confirm · Esc cancel`)
+- While a modal is open, world input (movement, abilities, R, Tab) is gated off — the
+  number and arrow keys belong to the modal — and only that arena's clock pauses
 
 ---
 
@@ -60,7 +73,7 @@ Build a guild powerful enough to simultaneously manage 8 different arenas, each 
 
 Arenic uses a **single keypress** input system - every action requires exactly one key press:
 
-- **Movement**: Each WASD press moves your character exactly one tile
+- **Movement**: Each arrow-key press moves your character exactly one tile
 - **Abilities**: Each number key (1-4) press activates the ability once
 - **No Held Keys**: Holding down movement keys does NOT create continuous movement
 - **Intent-Based**: The recording system captures when you pressed a key, not how long you held it
@@ -73,97 +86,110 @@ Arenic uses a **single keypress** input system - every action requires exactly o
 - Recordings are highly compressed and efficient
 
 **Example:**
-- ❌ **Wrong**: Hold W to move multiple tiles → Only moves one tile on initial press
-- ✅ **Correct**: Press W, W, W, W to move four tiles → Each press moves one tile
+- ❌ **Wrong**: Hold ↑ to move multiple tiles → Only moves one tile on initial press
+- ✅ **Correct**: Press ↑, ↑, ↑, ↑ to move four tiles → Each press moves one tile
 
 ---
 
 ## The Record & Replay System (Core Mechanic)
 
-The recording system allows you to capture 2-minute sequences of character actions that replay as autonomous "ghosts" every arena cycle. This core mechanic enables you to build up complex, coordinated strategies across multiple characters and arenas.
+The recording system allows you to capture 2-minute sequences of character actions that replay as autonomous "ghosts" every arena cycle. Think of it as sheet music: every arena cycle is a fixed 2-minute score, and each character owns a per-arena **staff** — a stream of intent events (moves and abilities). Committing a recording **folds** that staff into the arena's single **master timeline**, which choreographs all of the arena's ghosts (up to 40) at once.
 
 ### How Recording Works
 
 **Starting a Recording**
-- Press R while controlling any non-ghost character to begin recording
-- If pressed on a ghost that has a recording in current arena, shows replay dialog instead
-- A 3-second countdown prepares you before capture starts
-- The arena timer resets to 0:00 when recording begins
-- All your movements (WASD) and abilities (1-4 keys) are captured as intent
+- Press R while controlling the selected character; only one recording can be in progress at a time
+- No prior recording for this arena → the 3-second countdown starts immediately (no modal)
+- A prior recording exists for this arena → a modal asks **Record new** / **Replay previous** / **Cancel**
+- R on a selected ghost → a modal asks **Record new** / **Cancel** (recording anew unfolds the ghost's old events first)
+- During the countdown the recording arena is held at 0:00 — the other arenas keep playing
+- All input is ignored during the countdown — except **R**, which aborts it; movement and abilities register only once capture begins at 0:00
+- Capture runs as the clock ticks 0:00 → 2:00; all movements (arrow keys) and abilities (1-4 keys) are captured as intent, stamped with the arena's current tick
 
 **During Recording**
 - You have exactly 120 seconds to record your strategy
-- A red "RECORDING" indicator shows your current state
-- The timeline progress bar shows how much time remains
+- A red "REC" indicator and the arena clock show in the HUD while recording
+- Movement stays live inside the arena; stepping past an edge that has an adjacent arena opens the **Like the recording?** modal instead of silently moving you (at the outer world border the step simply clamps, recorded as played)
+- Tab is ignored while recording; the recording always belongs to the character who started it
 - Recording captures your input intent, not character position - ensuring perfect replay regardless of physics changes
 
 **Ending a Recording**
-- Recording automatically stops at the 2-minute mark
-- Press R again to manually interrupt recording early
-- A confirmation dialog appears with options:
-    - **Continue**: Return to active recording (keep recording)
-    - **Cancel**: Stop recording and discard progress
+- At the 2-minute mark the clock pauses and a modal asks **Commit** / **Discard**
+- Press R mid-recording to stop early: a modal asks **Commit partial** / **Keep recording** / **Discard**
+- A partial commit is simply a shorter event list — the ghost replays it, then idles for the rest of each cycle
+- On commit: the draft is cached in the character's per-arena library, folded into the arena's master timeline, the character becomes a ghost, and the arena restarts at 0:00
+- On discard: the draft is thrown away and the character stays selected
 
 **Recording Interruptions**
-- **Arena Switching**: Using [ ] or P (zoom) keys immediately stops recording with no confirmation
-- **Character Switching**: Pressing Tab shows confirmation dialog first:
-    - **Switch Character**: Stop recording and switch to next character
-    - **Continue Recording**: Cancel switch and return to recording
+- Tab is ignored while recording — a recording cannot be switched away from
+- Stepping past the arena edge opens the **Like the recording?** modal: **Continue recording** (abort the step) / **Cancel recording & walk out** (discard the draft, then perform the step) / **Commit** (fold the draft — you become a ghost and stay)
+- Camera keys ([ / ] and P) never stop a recording — watching another arena is safe
+- While any modal is open, only the recording arena's clock pauses
 
 ### Ghost Playback System
 
 **Autonomous Replay**
-- Ghosts automatically replay their recorded timeline every 2-minute arena cycle
-- Each arena maintains its own independent timer (0:00 to 2:00)
-- Ghosts in off-screen arenas continue advancing their timelines
-- When the timer loops back to 0:00, ghosts seamlessly restart
+- Each arena owns a single **master timeline**: every committed recording is cloned, tagged with its ghost, and folded into one tick-sorted event stream
+- Ghosts don't replay individual timelines — the arena plays its master timeline and drives all of its ghosts (up to 40) from it
+- Each arena maintains its own independent clock (0:00 to 2:00)
+- Ghosts in off-screen arenas continue advancing — their arenas never stop ticking
+- Whenever an arena (re)starts at 0:00 — natural clock wrap, recording start, commit, or replaying a stored recording — every folded ghost snaps to its recorded start tile and the score replays (breaking a ghost out does **not** restart the arena)
 
 **Visual Indicators**
-- Ghosts appear with blue tint and transparency effects
-- Ghost trails show recent movement paths
-- Character indicators above heads show state (green=active, red=recording, blue=ghost)
-- Cannot directly control ghosts - they follow their recorded timeline
+- Ghosts carry a blue ring; the selected character carries the white selection ring
+- A red "REC" label and the arena clock show in the HUD while recording; a countdown digit shows during the 3-second countdown
+- Cannot directly control ghosts - they follow the arena's master timeline (Tab can re-select one; press R on it to record anew, or an arrow key to break it out)
+
+**Breaking a Ghost Out**
+- Arrow keys never move a ghost directly — pressing one with a ghost selected opens the **Break out?** modal (pausing only that arena):
+    - **Take control**: the ghost's events are unfolded from the master timeline, the Ghost state is removed, and the arena **resumes right where it left off** (no restart) — the character stays at its current position under free control
+    - **Restart arena**: the arena restarts at 0:00 and every ghost snaps to its start — the character stays a folded ghost
+    - **Cancel**: nothing changes; playback resumes
+- A broken-out character keeps its cached recording: press **R** for *Record new / Replay previous / Cancel* — *Replay previous* folds it back in and restarts the arena
 
 **Timeline Accuracy**
-- Recording stores movement intent (WASD keys) not positions
-- Abilities trigger at exact recorded timestamps
-- Death events are captured and replayed
+- Recording stores movement intent (arrow-key presses) not positions — transforms are derived on playback
+- Events are stamped in ticks on the fixed 60 Hz timestep (7,200 ticks per 2-minute cycle), never in seconds
+- Each recording remembers its start tile, so every cycle replays from the same origin
+- Abilities trigger at exact recorded ticks
 - Perfect deterministic replay every cycle
 
 ### Multi-Arena Coordination
 
 **Independent Timers**
-- Each of the 9 arenas has its own 2-minute cycle timer
+- Each of the 9 arenas has its own 2-minute cycle clock
 - Ghosts use their parent arena's clock for playback
-- Switching arenas ([ ]) doesn't affect other arena timers
-- All timelines pause during dialog choices
+- Switching arenas ([ ]) doesn't affect other arena clocks
+- While a modal is open, **only the selected arena's clock pauses** — the other eight keep ticking
+- During a recording countdown, only the recording arena is held at 0:00
 
 **Cross-Arena Strategy**
 - Record complementary ghosts across multiple arenas
 - Use the arena status panel to track ghost counts per arena
 - Maximum of 40 ghosts per arena, 320 total across all arenas
-- Performance automatically adjusts update rates for distant arenas
+- (Future) rendering may scale down visual update rates for distant arenas; the simulation always ticks every arena at the fixed 60 Hz timestep
 
 ### Ghost Replay Feature
 
 **Arena-Specific Recordings**
-- Each character can store separate recordings for each of the 9 arenas
-- Recordings are stored in a per-character hashmap with arena as the key
-- Characters effectively become "multiple ghosts" - one per arena recorded in
+- Each character keeps a per-arena library of recordings (a hashmap keyed by arena) — its "staff" of sheet music per arena
+- A character is only ever a ghost in the arena it currently occupies; its other recordings wait in the library
+- Re-committing a recording for an arena replaces the old one (unfold first, then fold — always idempotent)
 
-**Returning to Previous Arenas**
-- When a ghost returns to an arena where they have a previous recording, a dialog appears
-- Options presented:
-    - **Replay Previous**: Use the stored recording for this arena
-    - **Draft New**: Convert ghost back to character for new recording
-    - **Cancel**: Continue without replaying
+**Travel: Leaving and Returning**
+- Travel is edge-walking: stepping past an arena edge re-parents the hero into the adjacent arena at the opposite edge
+- Edge-walking only applies between adjacent arenas — at the outer border of the 3×3 grid movement is clamped (the world does not wrap)
+- Ghosts never edge-walk: break the ghost out first (see **Breaking a Ghost Out**) — its events leave the master timeline at break-out and that arena keeps playing without restarting — then walk it wherever you like
+- When a hero edge-walks **into** an arena where it has a cached recording, a modal asks:
+    - **Replay previous**: fold the stored recording back into this arena's master timeline — the hero becomes a ghost and the arena restarts
+    - **Continue without**: stay a regular character (press R later to record new or replay via the R modal)
 - This allows the same character to have different tactical roles in different arenas
 
 **Strategic Applications**
 - Create arena-specific strategies with the same character
 - Build up recordings progressively as you learn each arena
 - Reuse successful recordings when returning to farm or practice
-- Maintain separate recordings for Normal/Heroic/Mythic difficulties
+- (Future) maintain separate recordings per difficulty tier — today the library is keyed by arena only
 
 ### Recording Best Practices
 
@@ -174,9 +200,8 @@ The recording system allows you to capture 2-minute sequences of character actio
 - Test ability combinations before committing
 
 **Optimization Tips**
-- Recordings automatically compress to save memory
-- Redundant movement events are filtered out
-- Only significant position changes create keyframes
+- The single-keypress system means recordings are already tiny — one small intent event per press
+- There are no keyframes: positions are derived on playback by replaying intent from the recorded start tile
 - Ability events are always preserved at full fidelity
 
 **Common Patterns**
@@ -188,22 +213,24 @@ The recording system allows you to capture 2-minute sequences of character actio
 ### Advanced Recording Features
 
 **State Management**
-- Recording state machine tracks: Idle → Countdown → Recording → Dialog
-- All state transitions logged for debugging
-- Global pause during dialogs ensures no missed actions
-- Event-driven architecture for reliable state changes
+- Recording state machine: Idle → Countdown (3s / 180 ticks) → Recording; modals are tracked separately and gate input while open
+- Exactly one recording can be in progress at a time; the global draft timeline is empty unless one is
+- Character states: **Selected** (controlled, input-driven) and **Ghost** (folded into its arena's master timeline, input ignored)
+- Commit transitions Selected → Ghost; "Record new" on a ghost or the break-out modal's "Take control" transitions Ghost → Selected after unfolding ("Take control" keeps the arena playing; "Record new" restarts it into a countdown)
+- While a modal is open only the selected arena pauses — there is no global pause
 
-**Performance Scaling**
-- Ghosts in current arena update at 60 FPS
-- Adjacent arena ghosts update at 30 FPS
-- Distant arena ghosts update at 10-15 FPS
-- Automatic quality adjustment when performance drops
+**Performance Scaling (future, render-side only)**
+- The simulation always advances every arena on the fixed 60 Hz tick — determinism is never traded away
+- Rendering / visual update rates may later scale down for distant arenas (e.g. 30 FPS adjacent, 10-15 FPS distant)
+- Automatic visual quality adjustment when performance drops
 
 **Technical Details**
-- Timeline events stored as intent (2 bytes) vs transform (48 bytes)
-- Binary search for efficient timeline lookups
-- Zero-allocation helpers for event queries
-- Arc<[T]> for cheap timeline sharing between systems
+- Simulation runs on the fixed 60 Hz timestep: `CYCLE_TICKS = 7_200`, `COUNTDOWN_TICKS = 180`; all timeline math is in ticks, never seconds, using `strict_*`/`wrapping_*`/`%` arithmetic
+- An event is intent, not position: `TimelineEvent { tick: u32, action: Action }` with `Action::Move(IVec2)` or `Action::Ability(u8)` — tiny and `Copy`
+- A recording is `Recording { start, events: Arc<[TimelineEvent]> }` — the start tile anchors every replay; `Arc` makes timeline sharing cheap
+- Each character carries a `RecordingLibrary` (hashmap: arena → recording); lookups by key only — the sim never iterates it
+- Each arena root carries the master timeline: a tick-sorted `Vec<GhostEvent>` (event + owning ghost entity) with a playback cursor; **fold** merges a recording in, **unfold** retains everything but one ghost's events
+- Commits are idempotent by construction: unfold first, then fold; the library insert replaces
 
 ---
 
@@ -265,7 +292,7 @@ Each class brings unique tactical advantages and 4 specialized abilities:
 ## Arena System & Boss Battles
 
 ### Arena Structure
-- **Grid Size**: 66×31 tiles per arena (1,254 tiles × 9 arenas = 11,286 total battlefield)
+- **Grid Size**: 66×31 tiles per arena (2,046 tiles × 9 arenas = 18,414 total battlefield)
 - **Boss Positioning**: Each arena contains one major boss matching its class theme
 - **Multi-Arena Management**: All 9 arenas run independently with separate timers
 - **Scaling Difficulty**: Normal → Heroic → Mythic progression tiers
@@ -303,23 +330,23 @@ Grid Layout (3×3):
 ### Arena Navigation & Camera System
 - **Arena Selection**: Use [ and ] keys to cycle through arenas (0-8, wraps around)
 - **Camera Zoom**: Press P to toggle between single arena view and all-arenas overview
-- **Visual Indicators**: Current arena highlighted with black border when zoomed out
+- **Visual Indicators**: Current arena highlighted with a white border when zoomed out
 - **Smart Focus**: Camera automatically positions on current arena when zooming in
-- **Character Memory**: Each arena remembers its last active hero for seamless transitions
+- **Character Memory**: Each arena remembers its last selected hero for seamless transitions
 
 ### Character Management Systems
-- **Active Character Toggle**: Tab cycles through heroes in current arena (requires 2+ heroes)
-- **Cross-Arena Movement**: WASD movement seamlessly transitions heroes between adjacent arenas
-- **Arena Boundaries**: Movement past edges teleports character to opposite side of adjacent arena
+- **Selection Toggle**: Tab cycles the Selected marker through heroes in the current arena (requires 2+ heroes)
+- **Cross-Arena Movement**: Arrow-key movement seamlessly transitions heroes between adjacent arenas (edge-walk; opens the interrupt modal while recording)
+- **Arena Boundaries**: Movement past edges teleports the character to the opposite side of the adjacent arena; the outer border of the 3×3 grid is clamped (no wraparound)
 - **Re-parenting System**: Characters automatically become children of their current arena entity
-- **State Preservation**: Heroes maintain active/inactive status when switching arenas
+- **State Preservation**: Heroes keep their selection when edge-walking between arenas
 
 ### Arena Update Logic
 - **Event-Driven Updates**: Arena state refreshes on camera changes or arena transitions
-- **Zoom-Out Behavior**: All characters deactivated (gray) for overview visibility
-- **Zoom-In Behavior**: Restores last active hero or activates first available character
+- **Zoom-Out Behavior**: The overview changes only the camera and HUD theme — selection (and its ring) is untouched
+- **Zoom-In Behavior**: Focuses the current arena; the selected hero keeps its ring
 - **Empty Arena Handling**: Gracefully handles arenas with no characters present
-- **Material System**: Blue material for active heroes, gray for inactive ones
+- **Selection Visuals**: A glowing ring marks the selected hero; ghosts carry a blue ring
 
 ### Boss Mechanics
 - **2-Minute Cycles**: Bosses operate on the same timing as your recordings
@@ -361,7 +388,7 @@ Grid Layout (3×3):
 - **Recruitment Review**: Open and evaluate new character acquisitions
 - **Global Buff Activation**: Use acquired consumables that affect all arenas simultaneously
 - **Strategic Planning**: Review arena status and plan multi-arena coordination
-- **Travel Coordination**: Manage character movement between different arenas
+- **Travel Planning**: Decide which arenas need heroes — travel itself is edge-walking
 
 ---
 
@@ -408,7 +435,7 @@ Grid Layout (3×3):
 - **Revival Abilities**: Cardinals and other healers can resurrect fallen allies
 - **Grid-Based Revival**: Revival spells target specific tiles rather than characters
 - **Timing Requirements**: Revival must occur when dead character is present at target location
-- **Recording Integration**: Deaths and revivals become part of the permanent timeline
+- **Recording Integration**: (Future) deaths and revivals will replay deterministically each cycle — derived from the intent timeline against the boss's fixed pattern, not stored as timeline events
 
 ---
 
@@ -421,7 +448,7 @@ Grid Layout (3×3):
 4. **Perfect Runs**: Complete mastery demonstrated through flawless execution
 
 ### Long-Term Goals
-- **Full Guild Development**: Recruit and develop 320+ heroes across all classes
+- **Full Guild Development**: Recruit and develop a full roster of 320 heroes across all classes
 - **Multi-Arena Excellence**: Successfully manage all 8 arenas simultaneously
 - **Strategic Mastery**: Create sophisticated recording combinations across multiple cycles
 - **Narrative Discovery**: Uncover the deeper story behind the arena conflicts
@@ -481,55 +508,55 @@ The game rewards both analytical optimization and creative experimentation, prov
 
 ## Technical Architecture Principles
 
-### Active Character Query Pattern
+### Selected Character Query Pattern
 
-**Architectural Rule**: All recording system operations should query for the Active Character dynamically rather than storing or passing character entities as parameters.
+**Architectural Rule**: All recording system operations query for the selected character (the `Selected` marker component) dynamically rather than storing or passing character entities as parameters.
 
 #### Implementation Principle
 ```rust
-// ✅ CORRECT - Query Active Character when needed
+// ✅ CORRECT - Query the Selected character when needed
 pub enum RecordingRequest {
-    Start,        // Query active_character_q.single() when processing
+    Start,        // Query the Selected character when processing
     Stop { reason: StopReason },
-    ShowDialog,   // Query active_character_q.single() when showing dialog
-    Commit,       // Query active_character_q.single() when committing
-    Clear,        // Query active_character_q.single() when clearing
+    ShowModal,    // Query the Selected character when showing the modal
+    Commit,       // Query the Selected character when committing
+    Clear,        // Query the Selected character when clearing
 }
 
 // ❌ INCORRECT - Storing/passing entities
 pub enum RecordingRequest {
     Start { entity: Entity },           // Don't store entities
-    ShowDialog { character: Entity },   // Don't pass character data
+    ShowModal { character: Entity },    // Don't pass character data
 }
 ```
 
 #### Rationale
-1. **Single Source of Truth**: The `Active` component determines which character receives input
-2. **R Key Behavior**: "R always operates on whoever is CURRENTLY active when pressed"
-3. **Dynamic Dialog Behavior**: Dialog should switch if player changes active character
-4. **Type Safety**: `active_character_q.single()` guarantees exactly one Active Character
+1. **Single Source of Truth**: The `Selected` marker determines which character receives input
+2. **R Key Behavior**: "R always operates on whoever is CURRENTLY selected when pressed"
+3. **Dynamic Modal Behavior**: The modal always reflects the currently selected character
+4. **Type Safety**: The `Single` system param guarantees exactly one selected character
 5. **Simplicity**: Eliminates entity synchronization and parameter passing complexity
 
 #### Query Pattern
 ```rust
-// Standard query for Active Character operations
-active_character_q: Single<(Entity, Option<&Ghost>), (With<Character>, With<Active>)>
+// Standard query for selected-character operations (Bevy 0.18 Single param)
+selected_q: Single<(Entity, Option<&Ghost>), With<Selected>>
 
 // Usage in recording systems
-let (character_entity, ghost_marker) = active_character_q.single();
+let (character_entity, ghost_marker) = *selected_q;
 ```
 
 #### Benefits
 - **Architectural Consistency**: All recording operations follow the same pattern
 - **Reduced Coupling**: No entity parameters between systems
-- **Automatic Updates**: Dialog and UI automatically reflect current active character
+- **Automatic Updates**: Modals and UI automatically reflect the currently selected character
 - **Performance**: O(1) queries with minimal overhead
 - **Maintainability**: Eliminates entity storage synchronization bugs
 
 #### Application Scope
 This pattern applies to:
 - All `RecordingRequest` variants
-- Dialog state management (`RecordingMode::DialogPaused`)
+- Modal state management (modal open ⇒ only the selected arena's clock pauses)
 - Recording state tracking
 - UI systems that need character context
 - Any system that operates on "the current character"

--- a/_docs/code-review.md
+++ b/_docs/code-review.md
@@ -177,6 +177,47 @@ component. Apply the intent, not the absolutism:
   they can desync from their inputs. (Central to arenic's record/replay: store the
   command stream, derive transforms on playback.)
 
+## Query & scheduling efficiency
+
+A query's signature is a **scheduling contract**: Bevy parallelizes by declared
+access, not by what a system happens to touch at runtime. Shape queries so the
+scheduler can do its job. (Run-condition gating and batch-over-lookup iteration
+are covered above — these rules are about the query shape itself.)
+
+- **Fetch only what you need.** Every component in the data tuple is fetched per
+  iteration and widens the access contract. A marker you only test for presence
+  belongs in the filter (`Query<&Transform, With<Selected>>`), never in the data
+  (`Query<(&Transform, &Selected)>`).
+- **`&mut T` only when the system actually mutates T.** Mutable access serializes
+  the system against every other reader/writer of T, and is where spurious
+  change ticks come from. If only a subset mutates, filter to that subset
+  instead of branching over a broad `&mut` query.
+- **Filter before branching.** Prefer a `With<T>`-narrowed system over fetching
+  `Has<T>` and branching in the loop body. `Has<T>` is for the genuine case of
+  ONE system whose per-entity behavior forks (e.g. `move_selected`'s
+  live-vs-ghost fork). `Option<&T>` additionally **widens** the matched set —
+  use it only when the shape really is "this base set, maybe with extra data",
+  never as a lazy substitute for a second, narrower system.
+- **`Changed<T>` is a deref flag, not a value diff.** It fires on every
+  `DerefMut` (and on add) — Bevy never compares old vs new. A system that
+  unconditionally writes re-dirties the world every frame and defeats every
+  downstream `Changed<T>` / `resource_changed` gate. Write-if-changed
+  (`set_if_neq`, or compare before assigning through `Mut`) is the discipline
+  that makes change-detection pipelines actually skip work.
+- **Iterate the smaller set.** When scoping work to one parent, a narrow marker
+  query filtered by `child_of.parent() == target` (tens of ghosts) beats walking
+  the parent's `Children` (thousands of tiles) and probing each — and the
+  reverse holds when the child list is the small side. Pick by cardinality, not
+  by idiom.
+- **Default (table) storage until measured.** Table storage iterates fast;
+  sparse-set trades iteration speed for cheap insert/remove. Don't reach for
+  `#[component(storage = "SparseSet")]` without a profile showing real
+  add/remove churn.
+- **Split systems by job, not into dust.** One system per behavior (capture,
+  movement, playback, HUD) — but ten fragments all mutating the same component
+  just force explicit ordering and serialize anyway. A good system reads: "when
+  this condition holds, operate on exactly this set of entities."
+
 ## Determinism (record/replay)
 
 Arenic is built around recording timelines and replaying them, so simulation code —

--- a/crates/arenic/src/intro_scene.rs
+++ b/crates/arenic/src/intro_scene.rs
@@ -13,18 +13,20 @@
 //! but stays centred on the overworld when zoomed out (only the selection border
 //! moves). The Guild House has **two guildmaster pucks**: `Tab` selects between them
 //! (a glowing ring marks the selected one), arrow keys step the selected puck one
-//! tile/press, `1` casts Holy Nova from it, `L` lavas its tile (a demo of the
+//! tile/press — stepping past an arena edge **edge-walks** into the adjacent arena
+//! — `1` casts Holy Nova from it, `R` records its staff (see `crate::recording` +
+//! RULEBOOK → Record & Replay), `L` lavas its tile (a demo of the
 //! [`arenic_game::tile::TileBoard`] API). `Esc` → title.
 
 use std::f32::consts::{FRAC_PI_2, FRAC_PI_8};
 
-use arenic_game::ability::{AbilityPlugin, AbilitySfx, holy_nova, play_sfx};
+use arenic_game::ability::{AbilityMeshes, AbilityPlugin, AbilitySfx, cast_holy_nova};
 use arenic_game::arena::{Arena, PropSpec};
 use arenic_game::atmosphere::{AtmospherePlugin, CloudFog, Plane, cloud_material};
 use arenic_game::boss::{BossSpec, LightBehavior, boss_a, light_offset};
 use arenic_game::grid::{
-    ARENA_H, ARENA_W, ARENAS, GRID_H, GRID_W, TILE, TileMover, arena_offset, arrow_delta,
-    arrow_pressed, board_center, tile_to_world,
+    ARENA_H, ARENA_W, ARENAS, GRID_H, GRID_W, TILE, TileMover, arena_offset, board_center,
+    tile_to_world,
 };
 use arenic_game::guildmaster::guildmaster;
 use arenic_game::swarm::{
@@ -33,6 +35,9 @@ use arenic_game::swarm::{
 };
 use arenic_game::theme::Theme;
 use arenic_game::tile::{ArenaTiles, Tile, TileBoard, TileKind, build_tile_materials};
+use arenic_game::timeline::{
+    Action, ArenaClock, ArenaTimeline, Ghost, RecordingLibrary, TimelineEvent,
+};
 use bevy::color::Alpha;
 use bevy::input::common_conditions::input_just_pressed;
 use bevy::light::{NotShadowCaster, NotShadowReceiver, ShadowFilteringMethod};
@@ -41,6 +46,10 @@ use bevy::prelude::*;
 use bevy::render::view::Hdr;
 
 use crate::hud::{BOTTOM_BAR_PX, TOP_BAR_PX};
+use crate::modal::no_modal;
+use crate::recording::{
+    DraftTimeline, RecordingState, is_idle, no_pending_walk, not_counting_down,
+};
 use crate::states::AppState;
 
 /// The Guild House — arena index 1 (top row, middle column); home of the puck.
@@ -83,9 +92,10 @@ pub(crate) struct ZoomOut;
 struct Puck(usize);
 
 /// Marks the currently-selected puck: it moves with the arrows, casts abilities, and
-/// wears the selection ring. Exactly one puck has this at a time.
+/// wears the selection ring. Exactly one puck has this at a time — recording
+/// systems query it dynamically (RULEBOOK → Selected Character Query Pattern).
 #[derive(Component)]
-struct Selected;
+pub(crate) struct Selected;
 
 /// The glowing selection halo; [`follow_selected`] parks it on the selected puck.
 #[derive(Component)]
@@ -114,23 +124,49 @@ impl Plugin for IntroScenePlugin {
             .add_systems(
                 Update,
                 (
+                    // World input gates off while a modal is open, a recording
+                    // countdown holds the arena (RULEBOOK → Modal Controls), or
+                    // a confirmed edge-walk is one frame from landing.
                     fire_holy_nova.run_if(
                         input_just_pressed(KeyCode::Digit1)
-                            .or(input_just_pressed(KeyCode::Numpad1)),
+                            .or(input_just_pressed(KeyCode::Numpad1))
+                            .and(no_modal)
+                            .and(not_counting_down)
+                            .and(no_pending_walk),
                     ),
                     toggle_zoom.run_if(input_just_pressed(KeyCode::KeyP)),
                     paginate.run_if(
                         input_just_pressed(KeyCode::BracketLeft)
                             .or(input_just_pressed(KeyCode::BracketRight)),
                     ),
-                    kindle.run_if(input_just_pressed(KeyCode::KeyL)),
-                    cycle_selection.run_if(input_just_pressed(KeyCode::Tab)),
-                    move_selected.run_if(arrow_pressed),
+                    refocus_camera.run_if(resource_changed::<CurrentArena>),
+                    // L mutates the board, which restart() can't rewind — idle only,
+                    // so a committed staff never replays against unrecorded state.
+                    kindle.run_if(
+                        input_just_pressed(KeyCode::KeyL)
+                            .and(no_modal)
+                            .and(is_idle)
+                            .and(no_pending_walk),
+                    ),
+                    // Tab is ignored while recording — the staff belongs to whoever
+                    // started it (RULEBOOK → Recording Interruptions) — and while a
+                    // pending walk could otherwise retarget Selected mid-handoff.
+                    cycle_selection.run_if(
+                        input_just_pressed(KeyCode::Tab)
+                            .and(no_modal)
+                            .and(is_idle)
+                            .and(no_pending_walk),
+                    ),
+                    // Arrow movement + edge-walking live in `crate::travel`.
                     follow_selected,
                     animate_swarm,
                     animate_boss_cores,
                     draw_overworld_gizmos.run_if(any_with_component::<ZoomOut>),
-                    back_to_title.run_if(input_just_pressed(KeyCode::Escape)),
+                    back_to_title.run_if(
+                        input_just_pressed(KeyCode::Escape)
+                            .and(no_modal)
+                            .and(is_idle),
+                    ),
                 )
                     .run_if(in_state(AppState::Intro)),
             );
@@ -224,6 +260,11 @@ fn setup_intro(
         let offset = arena_offset(index);
         let arena = commands
             .spawn((
+                // The arena root carries its identity, its 2-minute clock, and
+                // the master timeline its ghosts replay (RULEBOOK → sheet music).
+                arena_id,
+                ArenaClock::default(),
+                ArenaTimeline::default(),
                 Transform::from_xyz(offset.x, offset.y, 0.0),
                 Visibility::default(),
                 ChildOf(battleground),
@@ -331,6 +372,7 @@ fn setup_intro(
                     guildmaster(&assets),
                     Puck(i),
                     TileMover::new(col, row),
+                    RecordingLibrary::default(),
                     Transform::from_xyz(p.x, p.y, 0.05)
                         .with_rotation(Quat::from_rotation_x(FRAC_PI_2)),
                     ChildOf(arena),
@@ -509,50 +551,69 @@ fn animate_boss_cores(
 /// Demo of the tile-state API: `L` turns the tile under the puck to lava (move with
 /// the arrows first). Your game logic flips tiles the same way: `board.set(arena,
 /// col, row, TileKind::Lava)`.
-fn kindle(puck: Single<&TileMover, With<Selected>>, mut board: TileBoard) {
+fn kindle(
+    puck: Single<(&TileMover, &ChildOf), With<Selected>>,
+    arenas: Query<&Arena>,
+    mut board: TileBoard,
+) -> Result {
+    let (mover, child_of) = *puck;
+    let arena = arenas.get(child_of.parent())?;
     board.set(
-        GUILD_HOUSE,
-        puck.col as usize,
-        puck.row as usize,
+        arena.index(),
+        mover.col as usize,
+        mover.row as usize,
         TileKind::Lava,
     );
+    Ok(())
 }
 
-/// `Tab` moves the selection to the next guildmaster puck (cyclic, by [`Puck`] index).
+/// `Tab` moves the selection to the next guildmaster puck (cyclic, by [`Puck`]
+/// index). Focus follows selection: [`CurrentArena`] jumps to the new puck's
+/// arena (the zoomed-in camera + HUD re-theme), and the ring catches up via
+/// [`follow_selected`] — the same mechanism an edge-walk uses.
 fn cycle_selection(
     mut commands: Commands,
     selected: Single<(Entity, &Puck), With<Selected>>,
-    pucks: Query<(Entity, &Puck)>,
-) {
-    let (current, here) = *selected;
+    pucks: Query<(Entity, &Puck, &ChildOf)>,
+    arenas: Query<&Arena>,
+    mut current: ResMut<CurrentArena>,
+) -> Result {
+    let (current_puck, here) = *selected;
     let count = pucks.iter().count();
     debug_assert!(count > 0, "invariant: the Selected puck is in `pucks`");
     let next = here.0.strict_add(1) % count;
-    if let Some((entity, _)) = pucks.iter().find(|(_, p)| p.0 == next) {
-        commands.entity(current).remove::<Selected>();
+    if let Some((entity, _, child_of)) = pucks.iter().find(|(_, p, _)| p.0 == next) {
+        commands.entity(current_puck).remove::<Selected>();
         commands.entity(entity).insert(Selected);
+        current.0 = arenas.get(child_of.parent())?.index();
     }
+    Ok(())
 }
 
-/// Moves the SELECTED puck one tile per arrow-key press (clamped to the grid). Only
-/// the selected puck responds — the others hold position (this replaces the shared
-/// `grid::step_movers`, which would move every puck at once).
-fn move_selected(
-    keys: Res<ButtonInput<KeyCode>>,
-    selected: Single<(&mut TileMover, &mut Transform), With<Selected>>,
-) {
-    let (mut mover, mut transform) = selected.into_inner();
-    mover.step(&mut transform, arrow_delta(&keys));
-}
-
-/// Parks the selection ring on the selected puck (its local X/Y), so the halo tracks
-/// both `Tab` and arrow-key movement. The ring keeps its own Z.
+/// Parks the selection ring on the selected puck (its local X/Y), so the halo
+/// tracks `Tab`, arrow-key movement, AND arena changes: if the puck lives in a
+/// different arena than the ring (Tab across arenas, or an edge-walk), the ring
+/// re-parents first so the local copy lands in the right space. The ring keeps
+/// its own Z.
 fn follow_selected(
-    puck: Single<&Transform, (With<Selected>, Without<SelectionRing>)>,
-    mut ring: Single<&mut Transform, With<SelectionRing>>,
+    mut commands: Commands,
+    puck: Single<(&Transform, &ChildOf), (With<Selected>, Without<SelectionRing>)>,
+    ring: Single<(Entity, &mut Transform, &ChildOf), With<SelectionRing>>,
 ) {
-    ring.translation.x = puck.translation.x;
-    ring.translation.y = puck.translation.y;
+    let (puck_transform, puck_parent) = *puck;
+    let (entity, mut transform, ring_parent) = ring.into_inner();
+    if ring_parent.parent() != puck_parent.parent() {
+        commands
+            .entity(entity)
+            .insert(ChildOf(puck_parent.parent()));
+    }
+    // Write-if-changed: an unconditional write would re-dirty the ring's
+    // Transform (and its propagation) every frame the puck stands still.
+    let target = puck_transform.translation.truncate();
+    if transform.translation.truncate() != target {
+        transform.translation.x = target.x;
+        transform.translation.y = target.y;
+    }
 }
 
 /// `P` toggles the camera between the overworld (all 9 arenas) and a zoom on the
@@ -572,26 +633,26 @@ fn toggle_zoom(
     }
 }
 
-/// `[` / `]` select the previous / next arena (cyclic). Zoomed in, the camera
-/// follows to the new arena; zoomed out, it stays centred on the overworld and only
-/// the selection border (see [`draw_overworld_gizmos`]) moves.
-fn paginate(
-    keys: Res<ButtonInput<KeyCode>>,
-    mut current: ResMut<CurrentArena>,
-    camera: Single<(&mut Transform, Has<ZoomOut>), With<Camera3d>>,
-) {
-    let dir = keys.just_pressed(KeyCode::BracketRight) as i32
-        - keys.just_pressed(KeyCode::BracketLeft) as i32;
+/// `[` / `]` select the previous / next arena (cyclic). [`refocus_camera`] follows
+/// when zoomed in; zoomed out, only the selection border
+/// (see [`draw_overworld_gizmos`]) moves.
+fn paginate(keys: Res<ButtonInput<KeyCode>>, mut current: ResMut<CurrentArena>) {
+    let dir = (keys.just_pressed(KeyCode::BracketRight) as i32)
+        .strict_sub(keys.just_pressed(KeyCode::BracketLeft) as i32);
     if dir == 0 {
         return;
     }
     current.0 = (current.0 as i32).strict_add(dir).rem_euclid(ARENAS as i32) as usize;
-    let (mut transform, zoomed_out) = camera.into_inner();
-    if !zoomed_out {
-        // Zoomed in: follow the camera to the newly-selected arena.
-        *transform = camera_pose(current.0, ZOOM_IN);
-    }
-    // Zoomed out: the camera stays centred; the gizmo border follows `current`.
+}
+
+/// Re-poses the zoomed-in camera whenever [`CurrentArena`] changes (pagination or
+/// an edge-walk). Zoomed out ([`ZoomOut`] present) the `Single` filter finds no
+/// camera and the system is skipped — the overworld stays centred.
+fn refocus_camera(
+    current: Res<CurrentArena>,
+    mut camera: Single<&mut Transform, (With<Camera3d>, Without<ZoomOut>)>,
+) {
+    **camera = camera_pose(current.0, ZOOM_IN);
 }
 
 /// When zoomed out, draws the column dividers + a border around the current arena.
@@ -621,20 +682,34 @@ fn draw_overworld_gizmos(mut gizmos: Gizmos, current: Res<CurrentArena>) {
 }
 
 /// `1` (or numpad `1`) casts Holy Nova from the puck: the burst VFX + its sound.
+/// A selected ghost never casts live — its recorded casts play back instead.
+/// While recording, the cast lands in the draft HERE, atomically with the live
+/// effect (like movement in `travel::move_selected`), so the committed staff and
+/// the rehearsed take can never disagree about a cast.
 fn fire_holy_nova(
     mut commands: Commands,
-    player: Single<Entity, With<Selected>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    state: Res<RecordingState>,
+    mut draft: ResMut<DraftTimeline>,
+    player: Single<(Entity, &ChildOf), (With<Selected>, Without<Ghost>)>,
+    clocks: Query<&ArenaClock>,
+    meshes: Res<AbilityMeshes>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     sfx: Res<AbilitySfx>,
-) {
-    let color = Color::srgb(1.0, 0.9, 0.55); // holy gold
-    let burst = holy_nova(&mut meshes, &mut materials, color);
-    commands.spawn((burst, ChildOf(*player)));
-    play_sfx(&mut commands, sfx.holy_nova.clone());
+) -> Result {
+    let (player, child_of) = *player;
+    cast_holy_nova(&mut commands, &meshes, &mut materials, &sfx, player);
+    if matches!(*state, RecordingState::Recording) {
+        let tick = clocks.get(child_of.parent())?.tick;
+        draft.events.push(TimelineEvent {
+            tick,
+            action: Action::Ability(1),
+        });
+    }
+    Ok(())
 }
 
-/// `Esc` returns to the title (the 3D scene has no UI yet — this is the way out).
+/// `Esc` returns to the title — only while idle with no modal open (inside a
+/// modal, Esc is the cancel key; mid-recording it would destroy the draft).
 fn back_to_title(mut next: ResMut<NextState<AppState>>) {
     next.set(AppState::Title);
 }

--- a/crates/arenic/src/main.rs
+++ b/crates/arenic/src/main.rs
@@ -1,17 +1,24 @@
 mod hud;
 mod intro_scene;
+mod modal;
+mod recording;
 mod states;
 mod title_screen;
+mod travel;
 
 use arenic_game::default_font::DefaultFontPlugin;
 use arenic_game::default_plugins;
 use arenic_game::theme::ActiveTheme;
+use arenic_game::timeline::TimelinePlugin;
 use bevy::prelude::*;
 use bevy::window::WindowResolution;
 use hud::HudPlugin;
 use intro_scene::IntroScenePlugin;
+use modal::ModalPlugin;
+use recording::RecordingPlugin;
 use states::AppState;
 use title_screen::TitleScreenPlugin;
+use travel::TravelPlugin;
 
 fn main() -> AppExit {
     App::new()
@@ -31,6 +38,13 @@ fn main() -> AppExit {
         .init_resource::<ActiveTheme>()
         .add_plugins(TitleScreenPlugin)
         .add_plugins(IntroScenePlugin)
+        // The sheet-music sim: TimelinePlugin pins the 60 Hz fixed timestep and
+        // replays every arena's master timeline; Modal + Recording layer the
+        // keyboard-first capture/commit flows on top (`_docs/RULEBOOK.md`).
+        .add_plugins(TimelinePlugin)
+        .add_plugins(ModalPlugin)
+        .add_plugins(RecordingPlugin)
+        .add_plugins(TravelPlugin)
         .add_plugins(HudPlugin)
         .run()
 }

--- a/crates/arenic/src/modal.rs
+++ b/crates/arenic/src/modal.rs
@@ -1,0 +1,342 @@
+//! Keyboard-first confirmation modals — TUI-style (RULEBOOK → "Modal Controls").
+//!
+//! One modal at a time: [`spawn_modal`] builds a full-screen overlay (dim scrim,
+//! centred card, title + subtitle, a horizontal row of numbered options, and a
+//! bracketed hint bar) and inserts the [`ActiveModal`] resource. Interaction
+//! follows the Caves-of-Qud conventions: a digit activates its option instantly;
+//! `←`/`→`/`Tab` move a visible focus highlight; `Enter`/`Space` confirm the
+//! focused option; `Esc` always takes the [`Choice::Cancel`] option (never a
+//! destructive one) and is inert when the modal has none. The caller pre-focuses
+//! the *safe* option and pauses the affected arena's clock; every choice lands as
+//! a [`ModalChoice`] message for `recording::handle_choice` — the one place that
+//! closes the modal and applies the transition.
+
+use arenic_game::default_font::MonoFont;
+use arenic_game::theme::Theme;
+use arenic_game::timeline::ArenaClock;
+use bevy::prelude::*;
+
+use crate::states::AppState;
+
+/// Every decision a modal can resolve to, across all recording modals. `Cancel`
+/// is the universal safe option (`Esc`); the rest are the state transitions.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Choice {
+    /// Start (or restart) a recording for this arena — countdown begins.
+    StartRecording,
+    /// Fold the cached recording back into the arena and restart it.
+    ReplayPrevious,
+    /// Commit the draft (full or partial): cache, fold, become a ghost, restart.
+    Commit,
+    /// Throw the draft away; the character stays selected, the clock resumes.
+    Discard,
+    /// Throw the draft away, then perform the edge-walk that interrupted it.
+    DiscardAndWalk,
+    /// Break a ghost out: unfold its events; the arena keeps playing (no restart).
+    TakeControl,
+    /// Restart the arena at 0:00 — every ghost snaps to its start and stays folded.
+    RestartArena,
+    /// Close the modal and resume — the safe option every modal carries for `Esc`.
+    Cancel,
+}
+
+/// A picked modal option, consumed by `recording::handle_choice`.
+#[derive(Message)]
+pub(crate) struct ModalChoice(pub(crate) Choice);
+
+/// The open modal: its options (left → right), the focused index, and the two
+/// backgrounds the focus highlight swaps between. `just_opened` swallows the
+/// keypress that opened the modal so it can't also drive it.
+#[derive(Resource)]
+pub(crate) struct ActiveModal {
+    pub(crate) options: Vec<(&'static str, Choice)>,
+    pub(crate) focused: usize,
+    rest: Color,
+    focus: Color,
+    just_opened: bool,
+}
+
+/// The overlay root (despawned when any choice lands).
+#[derive(Component)]
+pub(crate) struct ModalRoot;
+
+/// One option button: its index in [`ActiveModal::options`].
+#[derive(Component)]
+#[component(immutable)]
+struct ModalOption(usize);
+
+/// The synchronous one-modal-at-a-time latch. [`ActiveModal`] itself lands via
+/// deferred `Commands`, so two systems in one frame could both pass a
+/// resource-existence check; this plain resource flips inside [`spawn_modal`]
+/// (and back in `recording::handle_choice`), so the second opener in a frame is
+/// gated out the moment the first one runs.
+#[derive(Resource, Default)]
+pub(crate) struct ModalLatch(pub(crate) bool);
+
+/// `true` while no modal is open or opening — gates every world-input system.
+pub(crate) fn no_modal(latch: Res<ModalLatch>) -> bool {
+    !latch.0
+}
+
+/// Spawns the overlay, registers it as the [`ActiveModal`], and pauses `clock`
+/// (the affected arena's) — a modal ALWAYS pauses exactly its arena, so the
+/// pairing lives here, not in caller convention. `focused` is the index
+/// pre-highlighted on open — always the safe option, never a destructive one.
+/// Returns `false` (a no-op) if a modal is already open — callers must not
+/// commit side effects (e.g. a `PendingWalk`) for a modal that never opened.
+#[must_use]
+pub(crate) fn spawn_modal(
+    commands: &mut Commands,
+    latch: &mut ModalLatch,
+    clock: &mut ArenaClock,
+    theme: &Theme,
+    mono: &MonoFont,
+    title: &str,
+    subtitle: &str,
+    options: &[(&'static str, Choice)],
+    focused: usize,
+) -> bool {
+    if latch.0 {
+        return false;
+    }
+    latch.0 = true;
+    clock.paused = true;
+
+    let rest = theme.surface_3();
+    let (focus, _press) = theme.interactions(rest);
+    commands.insert_resource(ActiveModal {
+        options: options.to_vec(),
+        focused: focused.min(options.len().saturating_sub(1)),
+        rest,
+        focus,
+        just_opened: true,
+    });
+
+    // Scrim root: dims the scene, centres the card, sits above the HUD.
+    let root = commands
+        .spawn((
+            ModalRoot,
+            DespawnOnExit(AppState::Intro),
+            GlobalZIndex(10),
+            Node {
+                position_type: PositionType::Absolute,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
+            BackgroundColor(theme.surface_overlay()),
+        ))
+        .id();
+
+    let card = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                row_gap: Val::Px(14.0),
+                padding: UiRect::axes(Val::Px(36.0), Val::Px(28.0)),
+                border_radius: BorderRadius::all(Val::Px(10.0)),
+                ..default()
+            },
+            BackgroundColor(theme.surface_2()),
+            ChildOf(root),
+            children![
+                (
+                    Text::new(title),
+                    TextFont {
+                        font_size: 26.0,
+                        ..default()
+                    },
+                    TextColor(theme.text_1()),
+                ),
+                (
+                    Text::new(subtitle),
+                    TextFont {
+                        font_size: 14.0,
+                        ..default()
+                    },
+                    TextColor(theme.text_muted()),
+                ),
+            ],
+        ))
+        .id();
+
+    // The horizontal option row: `[n]` hotkey chip + label per button.
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                column_gap: Val::Px(12.0),
+                margin: UiRect::top(Val::Px(8.0)),
+                ..default()
+            },
+            ChildOf(card),
+        ))
+        .id();
+    for (index, &(label, choice)) in options.iter().enumerate() {
+        commands
+            .spawn((
+                Button,
+                ModalOption(index),
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    column_gap: Val::Px(8.0),
+                    padding: UiRect::axes(Val::Px(18.0), Val::Px(12.0)),
+                    border_radius: BorderRadius::all(Val::Px(6.0)),
+                    ..default()
+                },
+                BackgroundColor(rest),
+                ChildOf(row),
+                children![
+                    (
+                        Text::new(format!("[{}]", index.strict_add(1))),
+                        TextFont {
+                            font: mono.0.clone(),
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(theme.text_muted()),
+                    ),
+                    (
+                        Text::new(label),
+                        TextFont {
+                            font_size: 15.0,
+                            ..default()
+                        },
+                        TextColor(theme.text_1()),
+                    ),
+                ],
+            ))
+            // Hover moves the focus highlight (keyboard and mouse share one focus).
+            .observe(
+                move |_: On<Pointer<Over>>, mut modal: ResMut<ActiveModal>| {
+                    modal.focused = index;
+                },
+            )
+            .observe(
+                move |_: On<Pointer<Click>>, mut choices: MessageWriter<ModalChoice>| {
+                    choices.write(ModalChoice(choice));
+                },
+            );
+    }
+
+    // Bracketed hint bar, Qud-style — built from the ACTUAL options so it never
+    // advertises a key that does nothing. Digits + arrows belong to the modal
+    // while it's open (world input is gated off).
+    let mut hint = format!(
+        "[1-{}] choose   [\u{2190}/\u{2192}] focus   [enter/space] confirm",
+        options.len()
+    );
+    if options.iter().any(|(_, c)| *c == Choice::Cancel) {
+        hint.push_str("   [esc] cancel");
+    }
+    commands.spawn((
+        Text::new(hint),
+        TextFont {
+            font: mono.0.clone(),
+            font_size: 12.0,
+            ..default()
+        },
+        TextColor(theme.text_muted()),
+        ChildOf(card),
+    ));
+    true
+}
+
+/// Drives the modal from the keyboard: digits activate instantly, `←`/`→`/`Tab`
+/// move focus (wrapping), `Enter`/`Space` confirm, `Esc` takes the Cancel option.
+fn modal_keys(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut modal: ResMut<ActiveModal>,
+    mut choices: MessageWriter<ModalChoice>,
+) {
+    if modal.just_opened {
+        // Swallow the press that opened the modal (e.g. the arrow key that
+        // triggered a break-out prompt) so it can't also drive the modal.
+        modal.just_opened = false;
+        return;
+    }
+    let count = modal.options.len();
+
+    // Digits (top row + numpad) pick an option instantly. All nine are wired so
+    // the `[1-N] choose` hint can never advertise a dead key.
+    const DIGITS: [(KeyCode, KeyCode); 9] = [
+        (KeyCode::Digit1, KeyCode::Numpad1),
+        (KeyCode::Digit2, KeyCode::Numpad2),
+        (KeyCode::Digit3, KeyCode::Numpad3),
+        (KeyCode::Digit4, KeyCode::Numpad4),
+        (KeyCode::Digit5, KeyCode::Numpad5),
+        (KeyCode::Digit6, KeyCode::Numpad6),
+        (KeyCode::Digit7, KeyCode::Numpad7),
+        (KeyCode::Digit8, KeyCode::Numpad8),
+        (KeyCode::Digit9, KeyCode::Numpad9),
+    ];
+    for (index, &(digit, numpad)) in DIGITS.iter().take(count).enumerate() {
+        if keys.just_pressed(digit) || keys.just_pressed(numpad) {
+            choices.write(ModalChoice(modal.options[index].1));
+            return;
+        }
+    }
+
+    if keys.just_pressed(KeyCode::Enter)
+        || keys.just_pressed(KeyCode::NumpadEnter)
+        || keys.just_pressed(KeyCode::Space)
+    {
+        choices.write(ModalChoice(modal.options[modal.focused].1));
+        return;
+    }
+    if keys.just_pressed(KeyCode::Escape)
+        && let Some(&(_, cancel)) = modal.options.iter().find(|(_, c)| *c == Choice::Cancel)
+    {
+        choices.write(ModalChoice(cancel));
+        return;
+    }
+
+    let shift = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+    let tab = keys.just_pressed(KeyCode::Tab);
+    if keys.just_pressed(KeyCode::ArrowRight) || (tab && !shift) {
+        modal.focused = modal.focused.strict_add(1) % count;
+    }
+    if keys.just_pressed(KeyCode::ArrowLeft) || (tab && shift) {
+        modal.focused = modal.focused.strict_add(count).strict_sub(1) % count;
+    }
+}
+
+/// Paints the focus highlight: the focused option wears the hover tint.
+fn sync_modal_focus(
+    modal: Res<ActiveModal>,
+    mut options: Query<(&ModalOption, &mut BackgroundColor)>,
+) {
+    for (option, mut bg) in &mut options {
+        bg.0 = if option.0 == modal.focused {
+            modal.focus
+        } else {
+            modal.rest
+        };
+    }
+}
+
+pub(crate) struct ModalPlugin;
+
+impl Plugin for ModalPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<ModalChoice>()
+            .init_resource::<ModalLatch>()
+            .add_systems(
+                Update,
+                (
+                    modal_keys,
+                    // Self-contained condition: survives a refactor that drops
+                    // the outer existence guard (resource_changed alone would
+                    // fail param validation when the resource is absent).
+                    sync_modal_focus.run_if(resource_exists_and_changed::<ActiveModal>),
+                )
+                    .chain()
+                    .run_if(resource_exists::<ActiveModal>)
+                    .run_if(in_state(AppState::Intro)),
+            );
+    }
+}

--- a/crates/arenic/src/recording.rs
+++ b/crates/arenic/src/recording.rs
@@ -1,0 +1,660 @@
+//! The recording state machine — R-key flows, intent capture, modal choices,
+//! ghost visuals, and the REC/clock HUD strip (RULEBOOK → Record & Replay).
+//!
+//! Exactly one recording exists at a time, held in the global [`RecordingState`]
+//! and [`DraftTimeline`] resources; the recording arena is always *the selected
+//! character's arena*, queried on demand and never stored (RULEBOOK → Selected
+//! Character Query Pattern). Every modal decision lands here in [`handle_choice`],
+//! the single, idempotent place state transitions are applied.
+
+use std::f32::consts::FRAC_PI_2;
+
+use arenic_game::arena::Arena;
+use arenic_game::default_font::MonoFont;
+use arenic_game::grid::TileMover;
+use arenic_game::timeline::{
+    Action, ArenaClock, ArenaTimeline, COUNTDOWN_TICKS, CYCLE_TICKS, Ghost, Recording,
+    RecordingLibrary, TICKS_PER_SECOND, TimelineEvent, TimelineSet, fold, restart, snap_ghost,
+    unfold,
+};
+use bevy::input::common_conditions::input_just_pressed;
+use bevy::light::{NotShadowCaster, NotShadowReceiver};
+use bevy::prelude::*;
+
+use crate::hud::TOP_BAR_PX;
+use crate::intro_scene::{CurrentArena, Selected};
+use crate::modal::{
+    ActiveModal, Choice, ModalChoice, ModalLatch, ModalRoot, no_modal, spawn_modal,
+};
+use crate::states::AppState;
+
+/// The one in-flight recording. `Countdown` holds the recording arena at tick 0
+/// for 3 seconds; `Recording` captures until the player commits/discards or the
+/// cycle fills.
+#[derive(Resource, Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(crate) enum RecordingState {
+    #[default]
+    Idle,
+    Countdown {
+        ticks_left: u32,
+    },
+    Recording,
+}
+
+/// The draft staff being captured — empty unless a recording is in flight.
+#[derive(Resource, Default)]
+pub(crate) struct DraftTimeline {
+    pub(crate) start: IVec2,
+    pub(crate) events: Vec<TimelineEvent>,
+}
+
+/// The edge-walk step that interrupted a recording, stashed while the
+/// *Like the recording?* modal is open. "Cancel & walk out" leaves it for
+/// `travel::perform_pending_walk`; every other choice clears it.
+#[derive(Resource)]
+pub(crate) struct PendingWalk(pub(crate) IVec2);
+
+/// Marks the blue ring child a [`Ghost`] wears (see [`ghost_ring_add`]).
+#[derive(Component)]
+struct GhostRing;
+
+/// One element of the REC/clock HUD strip under the top bar.
+#[derive(Component)]
+#[component(immutable)]
+enum RecHudPart {
+    Clock,
+    Rec,
+    Countdown,
+}
+
+pub(crate) fn is_idle(state: Res<RecordingState>) -> bool {
+    matches!(*state, RecordingState::Idle)
+}
+
+pub(crate) fn is_recording(state: Res<RecordingState>) -> bool {
+    matches!(*state, RecordingState::Recording)
+}
+
+pub(crate) fn not_counting_down(state: Res<RecordingState>) -> bool {
+    !matches!(*state, RecordingState::Countdown { .. })
+}
+
+/// `true` while no confirmed-but-unperformed edge-walk is in flight. World input
+/// (R, Tab, abilities, L) freezes for the one frame between "Cancel & walk out"
+/// and `travel::perform_pending_walk` — otherwise that input could re-arm a
+/// recording or retarget `Selected`, stranding the walk (or applying it to the
+/// wrong hero).
+pub(crate) fn no_pending_walk(pending: Option<Res<PendingWalk>>) -> bool {
+    pending.is_none()
+}
+
+fn counting_down(state: Res<RecordingState>) -> bool {
+    matches!(*state, RecordingState::Countdown { .. })
+}
+
+/// Holds `clock`/`timeline` at tick 0 (paused) and arms the draft — the 3-second
+/// countdown begins. Callers snap the arena's other ghosts to their starts.
+fn arm_countdown(
+    clock: &mut ArenaClock,
+    timeline: &mut ArenaTimeline,
+    draft: &mut DraftTimeline,
+    state: &mut RecordingState,
+    hero_tile: IVec2,
+) {
+    clock.tick = 0;
+    clock.paused = true;
+    timeline.cursor = 0;
+    draft.start = hero_tile;
+    draft.events.clear();
+    *state = RecordingState::Countdown {
+        ticks_left: COUNTDOWN_TICKS,
+    };
+}
+
+/// Folds `recording` for `hero` into the arena's master timeline, restarts the
+/// arena, and re-poses the hero as a ghost at the recording's start — the ONE
+/// commit/replay tail, so the two paths can't drift. The hero's `Ghost` marker
+/// lands via commands (deferred), so it is snapped by hand here; the caller
+/// snaps the arena's OTHER ghosts.
+fn fold_as_ghost(
+    commands: &mut Commands,
+    hero: Entity,
+    recording: &Recording,
+    clock: &mut ArenaClock,
+    timeline: &mut ArenaTimeline,
+    mover: &mut TileMover,
+    transform: &mut Transform,
+) {
+    fold(timeline, hero, recording);
+    restart(clock, timeline);
+    let ghost = Ghost {
+        start: recording.start,
+    };
+    snap_ghost(&ghost, mover, transform);
+    commands.entity(hero).insert(ghost);
+}
+
+/// Snaps every ghost parented to `arena` back to its recorded start tile —
+/// `except` skips a hero whose `Ghost` marker is mid-removal (commands defer).
+fn snap_arena_ghosts(
+    arena: Entity,
+    ghosts: &mut Query<(Entity, &Ghost, &ChildOf, &mut TileMover, &mut Transform)>,
+    except: Option<Entity>,
+) {
+    for (entity, ghost, child_of, mut mover, mut transform) in ghosts.iter_mut() {
+        if child_of.parent() == arena && except != Some(entity) {
+            snap_ghost(ghost, &mut mover, &mut transform);
+        }
+    }
+}
+
+/// `R` — the context-sensitive record key (RULEBOOK → Controls). No modal when
+/// there's no real choice: a fresh hero/arena pair goes straight to countdown.
+fn handle_r_key(
+    mut commands: Commands,
+    mono: Res<MonoFont>,
+    mut latch: ResMut<ModalLatch>,
+    mut state: ResMut<RecordingState>,
+    mut draft: ResMut<DraftTimeline>,
+    mut heroes: ParamSet<(
+        Query<(&ChildOf, Has<Ghost>, &RecordingLibrary, &TileMover), With<Selected>>,
+        Query<(Entity, &Ghost, &ChildOf, &mut TileMover, &mut Transform)>,
+    )>,
+    arena_ids: Query<&Arena>,
+    mut arenas: Query<(&Arena, &mut ArenaClock, &mut ArenaTimeline)>,
+) -> Result {
+    let (arena_entity, is_ghost, hero_tile, has_cache) = {
+        let p0 = heroes.p0();
+        let Ok((child_of, is_ghost, library, mover)) = p0.single() else {
+            return Ok(());
+        };
+        let arena_entity = child_of.parent();
+        let index = arena_ids.get(arena_entity)?.index() as u8;
+        (
+            arena_entity,
+            is_ghost,
+            IVec2::new(mover.col, mover.row),
+            library.0.contains_key(&index),
+        )
+    };
+    let (arena, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+    let theme = arena.theme().palette();
+
+    match *state {
+        RecordingState::Countdown { .. } => {
+            // R again aborts the countdown — nothing has been captured yet.
+            *state = RecordingState::Idle;
+            draft.events.clear();
+            clock.paused = false;
+        }
+        RecordingState::Recording => {
+            let _ = spawn_modal(
+                &mut commands,
+                &mut latch,
+                &mut clock,
+                &theme,
+                &mono,
+                "Like the recording?",
+                "Commit folds this draft into the arena's timeline",
+                &[
+                    ("Commit", Choice::Commit),
+                    ("Keep recording", Choice::Cancel),
+                    ("Discard", Choice::Discard),
+                ],
+                1,
+            );
+        }
+        RecordingState::Idle if is_ghost => {
+            let _ = spawn_modal(
+                &mut commands,
+                &mut latch,
+                &mut clock,
+                &theme,
+                &mono,
+                "Record over this ghost?",
+                "Record new unfolds it and starts the countdown",
+                &[
+                    ("Record new", Choice::StartRecording),
+                    ("Cancel", Choice::Cancel),
+                ],
+                1,
+            );
+        }
+        RecordingState::Idle if has_cache => {
+            let _ = spawn_modal(
+                &mut commands,
+                &mut latch,
+                &mut clock,
+                &theme,
+                &mono,
+                "This hero has a staff here",
+                "Record new replaces it - Replay folds the old one back in",
+                &[
+                    ("Record new", Choice::StartRecording),
+                    ("Replay previous", Choice::ReplayPrevious),
+                    ("Cancel", Choice::Cancel),
+                ],
+                2,
+            );
+        }
+        RecordingState::Idle => {
+            arm_countdown(&mut clock, &mut timeline, &mut draft, &mut state, hero_tile);
+            snap_arena_ghosts(arena_entity, &mut heroes.p1(), None);
+        }
+    }
+    Ok(())
+}
+
+/// Mirrors the not-yet-implemented ability slots (2-4) into the draft while
+/// recording, stamped with the recording arena's current tick. Captured in
+/// `Update` so `just_pressed` edges are never missed; the stamp quantizes the
+/// intent onto the tick grid. Anything with a LIVE effect records atomically
+/// where it applies instead — movement in `travel::move_selected`, slot 1 in
+/// `intro_scene::fire_holy_nova` — so the committed staff can never contain an
+/// event the live take didn't perform (or vice versa).
+fn capture_intent(
+    keys: Res<ButtonInput<KeyCode>>,
+    selected: Single<&ChildOf, With<Selected>>,
+    clocks: Query<&ArenaClock>,
+    mut draft: ResMut<DraftTimeline>,
+) -> Result {
+    let tick = clocks.get(selected.parent())?.tick;
+    const SLOTS: [(KeyCode, KeyCode, u8); 3] = [
+        (KeyCode::Digit2, KeyCode::Numpad2, 2),
+        (KeyCode::Digit3, KeyCode::Numpad3, 3),
+        (KeyCode::Digit4, KeyCode::Numpad4, 4),
+    ];
+    for (digit, numpad, slot) in SLOTS {
+        if keys.just_pressed(digit) || keys.just_pressed(numpad) {
+            draft.events.push(TimelineEvent {
+                tick,
+                action: Action::Ability(slot),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Counts the 3-second countdown down; at zero the recording arena's clock is
+/// released and capture begins.
+fn tick_countdown(
+    mut state: ResMut<RecordingState>,
+    selected: Single<&ChildOf, With<Selected>>,
+    mut clocks: Query<&mut ArenaClock>,
+) -> Result {
+    let RecordingState::Countdown { ticks_left } = &mut *state else {
+        return Ok(());
+    };
+    *ticks_left = ticks_left.strict_sub(1);
+    if *ticks_left == 0 {
+        clocks.get_mut(selected.parent())?.paused = false;
+        *state = RecordingState::Recording;
+    }
+    Ok(())
+}
+
+/// When the recording arena's clock reaches the end of the cycle, pause it and
+/// ask the player to commit or discard — the 2-minute staff is full.
+fn auto_stop(
+    mut commands: Commands,
+    mono: Res<MonoFont>,
+    mut latch: ResMut<ModalLatch>,
+    selected: Single<&ChildOf, With<Selected>>,
+    mut arenas: Query<(&Arena, &mut ArenaClock)>,
+) -> Result {
+    let (arena, mut clock) = arenas.get_mut(selected.parent())?;
+    if clock.tick < CYCLE_TICKS.strict_sub(1) {
+        return Ok(());
+    }
+    let _ = spawn_modal(
+        &mut commands,
+        &mut latch,
+        &mut clock,
+        &arena.theme().palette(),
+        &mono,
+        "Time's up - like the recording?",
+        "The two-minute cycle is full",
+        &[("Commit", Choice::Commit), ("Discard", Choice::Discard)],
+        0,
+    );
+    Ok(())
+}
+
+/// Applies the choice made on ANY modal — the one place recording transitions
+/// happen, so each is explicit and idempotent. Closes the modal first; every
+/// branch then resumes, restarts, or re-arms the affected arena deliberately.
+fn handle_choice(
+    mut commands: Commands,
+    mut choices: MessageReader<ModalChoice>,
+    mut state: ResMut<RecordingState>,
+    mut draft: ResMut<DraftTimeline>,
+    mut heroes: ParamSet<(
+        Query<
+            (
+                Entity,
+                &ChildOf,
+                &mut RecordingLibrary,
+                &mut TileMover,
+                &mut Transform,
+            ),
+            With<Selected>,
+        >,
+        Query<(Entity, &Ghost, &ChildOf, &mut TileMover, &mut Transform)>,
+    )>,
+    mut arenas: Query<(&Arena, &mut ArenaClock, &mut ArenaTimeline)>,
+    roots: Query<Entity, With<ModalRoot>>,
+    mut latch: ResMut<ModalLatch>,
+) -> Result {
+    let Some(&ModalChoice(choice)) = choices.read().next() else {
+        return Ok(());
+    };
+    choices.clear();
+    if !latch.0 {
+        // A mashed press that landed after the modal already closed — drop it.
+        return Ok(());
+    }
+    latch.0 = false;
+
+    // Close the modal; the branches below decide how the arena resumes.
+    commands.remove_resource::<ActiveModal>();
+    for root in &roots {
+        commands.entity(root).despawn();
+    }
+    if choice != Choice::DiscardAndWalk {
+        commands.remove_resource::<PendingWalk>();
+    }
+
+    let (hero, arena_entity, hero_tile) = {
+        let p0 = heroes.p0();
+        let Ok((hero, child_of, _, mover, _)) = p0.single() else {
+            return Ok(());
+        };
+        (hero, child_of.parent(), IVec2::new(mover.col, mover.row))
+    };
+
+    match choice {
+        Choice::Cancel => {
+            // Resume exactly where the modal froze the arena.
+            arenas.get_mut(arena_entity)?.1.paused = false;
+        }
+        Choice::Discard | Choice::DiscardAndWalk => {
+            // Throw the draft away; the hero stays selected where it stands.
+            // DiscardAndWalk leaves `PendingWalk` for the intro scene to perform.
+            *state = RecordingState::Idle;
+            draft.events.clear();
+            arenas.get_mut(arena_entity)?.1.paused = false;
+        }
+        Choice::Commit => {
+            *state = RecordingState::Idle;
+            let recording = Recording {
+                start: draft.start,
+                events: draft.events.drain(..).collect(),
+            };
+            {
+                let mut p0 = heroes.p0();
+                let (_, _, mut library, mut mover, mut transform) = p0.single_mut()?;
+                let (arena, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+                library.0.insert(arena.index() as u8, recording.clone());
+                fold_as_ghost(
+                    &mut commands,
+                    hero,
+                    &recording,
+                    &mut clock,
+                    &mut timeline,
+                    &mut mover,
+                    &mut transform,
+                );
+            }
+            snap_arena_ghosts(arena_entity, &mut heroes.p1(), None);
+        }
+        Choice::ReplayPrevious => {
+            {
+                let mut p0 = heroes.p0();
+                let (_, _, library, mut mover, mut transform) = p0.single_mut()?;
+                let (arena, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+                let Some(recording) = library.0.get(&(arena.index() as u8)) else {
+                    // No cache after all (shouldn't happen) — at least resume.
+                    clock.paused = false;
+                    return Ok(());
+                };
+                fold_as_ghost(
+                    &mut commands,
+                    hero,
+                    recording,
+                    &mut clock,
+                    &mut timeline,
+                    &mut mover,
+                    &mut transform,
+                );
+            }
+            snap_arena_ghosts(arena_entity, &mut heroes.p1(), None);
+        }
+        Choice::StartRecording => {
+            let (_, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+            if heroes.p1().get(hero).is_ok() {
+                // Re-recording a ghost: pull its old events out first.
+                unfold(&mut timeline, hero, clock.tick);
+                commands.entity(hero).remove::<Ghost>();
+            }
+            arm_countdown(&mut clock, &mut timeline, &mut draft, &mut state, hero_tile);
+            snap_arena_ghosts(arena_entity, &mut heroes.p1(), Some(hero));
+        }
+        Choice::TakeControl => {
+            // Break-out: the events leave the score, the arena keeps playing
+            // right where it left off, and the hero is free at its current tile.
+            let (_, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+            unfold(&mut timeline, hero, clock.tick);
+            clock.paused = false;
+            commands.entity(hero).remove::<Ghost>();
+        }
+        Choice::RestartArena => {
+            // "I made a mistake": rewind everything; the hero stays folded.
+            let (_, mut clock, mut timeline) = arenas.get_mut(arena_entity)?;
+            restart(&mut clock, &mut timeline);
+            snap_arena_ghosts(arena_entity, &mut heroes.p1(), None);
+        }
+    }
+    Ok(())
+}
+
+/// Dresses a fresh [`Ghost`] in its blue ring — the sibling of the white
+/// selection halo (same `Annulus` recipe, ghost-blue, slightly wider so the two
+/// read concentrically on a selected ghost). Parented to the puck, so it follows
+/// playback; the puck is X-rotated 90°, so the ring counter-rotates to lie flat.
+fn ghost_ring_add(
+    add: On<Add, Ghost>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let blue = Color::srgb(0.35, 0.55, 1.0);
+    let l = blue.to_linear();
+    commands.spawn((
+        GhostRing,
+        Mesh3d(meshes.add(Annulus::new(0.32, 0.38))),
+        MeshMaterial3d(materials.add(StandardMaterial {
+            base_color: blue,
+            emissive: LinearRgba::rgb(l.red, l.green, l.blue) * 2.5,
+            ..default()
+        })),
+        Transform::from_xyz(0.0, -0.02, 0.0).with_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
+        NotShadowCaster,
+        NotShadowReceiver,
+        ChildOf(add.entity),
+    ));
+}
+
+/// Removes the blue ring when its ghost breaks out / records anew.
+fn ghost_ring_remove(
+    remove: On<Remove, Ghost>,
+    mut commands: Commands,
+    rings: Query<(Entity, &ChildOf), With<GhostRing>>,
+) {
+    for (ring, child_of) in &rings {
+        if child_of.parent() == remove.entity {
+            commands.entity(ring).despawn();
+        }
+    }
+}
+
+/// The thin strip under the top bar: `REC` while recording, the selected arena's
+/// clock as `m:ss`, and the countdown digit. Spawned in the current arena's
+/// tokens; [`update_rec_hud`] re-tokens as focus moves.
+fn setup_rec_hud(mut commands: Commands, mono: Res<MonoFont>, current: Res<CurrentArena>) {
+    let theme = Arena::from_index(current.0)
+        .expect("invariant: CurrentArena is a valid arena index")
+        .theme()
+        .palette();
+    let mono_text = |size: f32| TextFont {
+        font: mono.0.clone(),
+        font_size: size,
+        ..default()
+    };
+    commands.spawn((
+        DespawnOnExit(AppState::Intro),
+        GlobalZIndex(5),
+        Pickable::IGNORE,
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(TOP_BAR_PX + 8.0),
+            width: Val::Percent(100.0),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            column_gap: Val::Px(10.0),
+            ..default()
+        },
+        children![
+            (
+                RecHudPart::Rec,
+                Text::new("REC"),
+                mono_text(14.0),
+                TextColor(theme.error),
+                Visibility::Hidden,
+            ),
+            (
+                RecHudPart::Clock,
+                Text::new("0:00"),
+                mono_text(14.0),
+                TextColor(theme.text_1()),
+            ),
+            (
+                RecHudPart::Countdown,
+                Text::new(""),
+                mono_text(22.0),
+                TextColor(theme.warning),
+                Visibility::Hidden,
+            ),
+        ],
+    ));
+}
+
+/// Drives the strip from the selected hero's arena: its clock, the REC flag, and
+/// the countdown digit, themed to that arena's palette.
+fn update_rec_hud(
+    state: Res<RecordingState>,
+    selected: Single<&ChildOf, With<Selected>>,
+    arenas: Query<(&Arena, &ArenaClock)>,
+    mut parts: Query<(&RecHudPart, &mut Text, &mut TextColor, &mut Visibility)>,
+) -> Result {
+    let (arena, clock) = arenas.get(selected.parent())?;
+    let theme = arena.theme().palette();
+    // Write-if-changed throughout: an unconditional `text.0 =` would mark the
+    // Text changed and re-shape its glyphs every frame for a string that only
+    // changes once a second.
+    let set_text = |text: &mut Mut<Text>, s: String| {
+        if text.0 != s {
+            text.0 = s;
+        }
+    };
+    let set_color = |color: &mut Mut<TextColor>, c: Color| {
+        if color.0 != c {
+            color.0 = c;
+        }
+    };
+    let set_visible = |visibility: &mut Mut<Visibility>, on: bool| {
+        let v = if on {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
+        if **visibility != v {
+            **visibility = v;
+        }
+    };
+    for (part, mut text, mut color, mut visibility) in &mut parts {
+        match part {
+            RecHudPart::Clock => {
+                let secs = clock.tick / TICKS_PER_SECOND;
+                set_text(&mut text, format!("{}:{:02}", secs / 60, secs % 60));
+                set_color(&mut color, theme.text_1());
+            }
+            RecHudPart::Rec => {
+                set_color(&mut color, theme.error);
+                set_visible(&mut visibility, matches!(*state, RecordingState::Recording));
+            }
+            RecHudPart::Countdown => {
+                set_color(&mut color, theme.warning);
+                if let RecordingState::Countdown { ticks_left } = *state {
+                    set_text(&mut text, ticks_left.div_ceil(TICKS_PER_SECOND).to_string());
+                    set_visible(&mut visibility, true);
+                } else {
+                    set_visible(&mut visibility, false);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Leaving the intro scene mid-recording drops everything cleanly (the entities
+/// despawn via `DespawnOnExit`; the globals reset here).
+fn reset_on_exit(
+    mut commands: Commands,
+    mut state: ResMut<RecordingState>,
+    mut draft: ResMut<DraftTimeline>,
+    mut latch: ResMut<ModalLatch>,
+) {
+    *state = RecordingState::Idle;
+    draft.events.clear();
+    latch.0 = false;
+    commands.remove_resource::<ActiveModal>();
+    commands.remove_resource::<PendingWalk>();
+}
+
+pub(crate) struct RecordingPlugin;
+
+impl Plugin for RecordingPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<RecordingState>()
+            .init_resource::<DraftTimeline>()
+            .add_observer(ghost_ring_add)
+            .add_observer(ghost_ring_remove)
+            .add_systems(OnEnter(AppState::Intro), setup_rec_hud)
+            .add_systems(OnExit(AppState::Intro), reset_on_exit)
+            .add_systems(
+                Update,
+                (
+                    handle_r_key.run_if(
+                        input_just_pressed(KeyCode::KeyR)
+                            .and(no_modal)
+                            .and(no_pending_walk),
+                    ),
+                    capture_intent.run_if(is_recording.and(no_modal)),
+                    // Gated on a pending message: the heavy ParamSet (and its
+                    // mutable access) is skipped entirely on choice-less frames.
+                    handle_choice.run_if(on_message::<ModalChoice>),
+                    update_rec_hud,
+                )
+                    .run_if(in_state(AppState::Intro)),
+            )
+            .add_systems(
+                FixedUpdate,
+                (
+                    tick_countdown.run_if(counting_down),
+                    auto_stop.run_if(is_recording),
+                )
+                    .after(TimelineSet)
+                    .run_if(no_modal.and(in_state(AppState::Intro))),
+            );
+    }
+}

--- a/crates/arenic/src/travel.rs
+++ b/crates/arenic/src/travel.rs
@@ -1,0 +1,314 @@
+//! Hero **travel**: arrow-key tile steps, edge-walking between adjacent arenas,
+//! and the travel-adjacent modals (ghost break-out, the mid-recording interrupt,
+//! replay-on-return). Split out of `intro_scene` along the movement fault line —
+//! the scene owns what the world *is*; this module owns how the selected hero
+//! *moves through it* (RULEBOOK → Travel: Leaving and Returning).
+
+use arenic_game::arena::Arena;
+use arenic_game::default_font::MonoFont;
+use arenic_game::grid::{MAX_COL, MAX_ROW, TileMover, arrow_delta, arrow_pressed};
+use arenic_game::timeline::{Action, ArenaClock, Ghost, RecordingLibrary, TimelineEvent};
+use bevy::prelude::*;
+
+use crate::intro_scene::{CurrentArena, Selected};
+use crate::modal::{Choice, ModalLatch, no_modal, spawn_modal};
+use crate::recording::{DraftTimeline, PendingWalk, RecordingState, is_idle, not_counting_down};
+use crate::states::AppState;
+
+/// Moves the SELECTED puck one tile per arrow-key press. Only the selected puck
+/// responds — the others hold position. Three special cases (RULEBOOK):
+/// a selected **ghost** never moves — an arrow press opens the *Break out?* modal;
+/// stepping past the arena edge **while recording** opens the *Like the
+/// recording?* interrupt modal; the same step while idle **edge-walks** into the
+/// adjacent arena.
+fn move_selected(
+    mut commands: Commands,
+    keys: Res<ButtonInput<KeyCode>>,
+    state: Res<RecordingState>,
+    mut latch: ResMut<ModalLatch>,
+    mut draft: ResMut<DraftTimeline>,
+    mono: Res<MonoFont>,
+    selected: Single<
+        (
+            Entity,
+            &mut TileMover,
+            &mut Transform,
+            &ChildOf,
+            Has<Ghost>,
+            &RecordingLibrary,
+        ),
+        With<Selected>,
+    >,
+    arena_roots: Query<(Entity, &Arena)>,
+    mut clocks: Query<&mut ArenaClock>,
+    mut current: ResMut<CurrentArena>,
+) -> Result {
+    let delta = arrow_delta(&keys);
+    let (hero, mut mover, mut transform, child_of, is_ghost, library) = selected.into_inner();
+    let arena_entity = child_of.parent();
+    let (_, arena) = arena_roots.get(arena_entity)?;
+    let recording = matches!(*state, RecordingState::Recording);
+
+    if is_ghost {
+        // Arrows never drive a ghost — ask before pulling it out of the score.
+        let mut clock = clocks.get_mut(arena_entity)?;
+        let _ = spawn_modal(
+            &mut commands,
+            &mut latch,
+            &mut clock,
+            &arena.theme().palette(),
+            &mono,
+            "Break out of the recording?",
+            "Take control unfolds this hero - the arena keeps playing",
+            &[
+                ("Take control", Choice::TakeControl),
+                ("Restart arena", Choice::RestartArena),
+                ("Cancel", Choice::Cancel),
+            ],
+            2,
+        );
+        return Ok(());
+    }
+
+    let target = IVec2::new(mover.col.strict_add(delta.x), mover.row.strict_add(delta.y));
+    let inside = (0..=MAX_COL).contains(&target.x) && (0..=MAX_ROW).contains(&target.y);
+    let crossing = if inside {
+        None
+    } else {
+        adjacent_entry(arena.index(), mover.col, mover.row, delta)
+    };
+
+    match crossing {
+        None => {
+            // In bounds — or clamped at the outer world border, exactly like
+            // replay clamps. The step APPLIES, so it is what the draft records:
+            // a blocked step (the interrupt arm below) never leaves a phantom
+            // event in the committed staff.
+            mover.step(&mut transform, delta);
+            if recording {
+                let tick = clocks.get(arena_entity)?.tick;
+                draft.events.push(TimelineEvent {
+                    tick,
+                    action: Action::Move(delta),
+                });
+            }
+        }
+        Some(_) if recording => {
+            // Mid-recording edge step into a real neighbour: confirm before
+            // anything is lost. The PendingWalk only exists if the modal really
+            // opened — a stranded one would suppress movement forever.
+            let mut clock = clocks.get_mut(arena_entity)?;
+            if spawn_modal(
+                &mut commands,
+                &mut latch,
+                &mut clock,
+                &arena.theme().palette(),
+                &mono,
+                "Like the recording?",
+                "Moving out of the arena cancels it",
+                &[
+                    ("Continue recording", Choice::Cancel),
+                    ("Cancel & walk out", Choice::DiscardAndWalk),
+                    ("Commit & stay", Choice::Commit),
+                ],
+                0,
+            ) {
+                commands.insert_resource(PendingWalk(delta));
+            }
+        }
+        Some(entry) => {
+            edge_walk(
+                &mut commands,
+                &mut latch,
+                &mono,
+                hero,
+                &mut mover,
+                &mut transform,
+                entry,
+                library,
+                &arena_roots,
+                &mut clocks,
+                &mut current,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Where stepping `delta` from `(col, row)` lands when it crosses the edge of
+/// arena `index`: `(adjacent arena, entry col, entry row)` on the opposite edge,
+/// or `None` at the outer border of the 3×3 world (movement clamps; no wrap).
+fn adjacent_entry(index: usize, col: i32, row: i32, delta: IVec2) -> Option<(usize, i32, i32)> {
+    let target = IVec2::new(col.strict_add(delta.x), row.strict_add(delta.y));
+    let (grid_col, grid_row) = (index % 3, index / 3);
+    if target.x > MAX_COL && grid_col < 2 {
+        Some((index.strict_add(1), 0, target.y.clamp(0, MAX_ROW)))
+    } else if target.x < 0 && grid_col > 0 {
+        Some((index.strict_sub(1), MAX_COL, target.y.clamp(0, MAX_ROW)))
+    } else if target.y > MAX_ROW && grid_row > 0 {
+        // Within an arena +row is up; the arena above sits at index − 3.
+        Some((index.strict_sub(3), target.x.clamp(0, MAX_COL), 0))
+    } else if target.y < 0 && grid_row < 2 {
+        Some((index.strict_add(3), target.x.clamp(0, MAX_COL), MAX_ROW))
+    } else {
+        None
+    }
+}
+
+/// Re-parents the hero into the adjacent arena at `entry` (from
+/// [`adjacent_entry`]), refocuses [`CurrentArena`] (the camera follows when
+/// zoomed in; the ring catches up via `intro_scene::follow_selected`), and — if
+/// the hero has a staff cached for the new arena — asks whether to fold it back
+/// in (RULEBOOK → Travel: Leaving and Returning).
+fn edge_walk(
+    commands: &mut Commands,
+    latch: &mut ModalLatch,
+    mono: &MonoFont,
+    hero: Entity,
+    mover: &mut TileMover,
+    transform: &mut Transform,
+    entry: (usize, i32, i32),
+    library: &RecordingLibrary,
+    arena_roots: &Query<(Entity, &Arena)>,
+    clocks: &mut Query<&mut ArenaClock>,
+    current: &mut CurrentArena,
+) -> Result {
+    let (to_index, col, row) = entry;
+    let Some((to_arena, arena)) = arena_roots.iter().find(|(_, a)| a.index() == to_index) else {
+        return Ok(());
+    };
+    mover.snap_to(transform, col, row);
+    commands.entity(hero).insert(ChildOf(to_arena));
+    current.0 = to_index;
+
+    // Returning with a staff for this arena? Offer to fold it back in.
+    if library.0.contains_key(&(to_index as u8)) {
+        let mut clock = clocks.get_mut(to_arena)?;
+        let _ = spawn_modal(
+            commands,
+            latch,
+            &mut clock,
+            &arena.theme().palette(),
+            mono,
+            "Replay this hero's staff here?",
+            "Replay folds the cached recording back in and restarts the arena",
+            &[
+                ("Replay previous", Choice::ReplayPrevious),
+                ("Continue without", Choice::Cancel),
+            ],
+            1,
+        );
+    }
+    Ok(())
+}
+
+/// Performs the edge-walk the player confirmed from the interrupt modal
+/// ("Cancel & walk out") — the draft was discarded by `recording::handle_choice`;
+/// the stashed step happens now.
+fn perform_pending_walk(
+    mut commands: Commands,
+    pending: Res<PendingWalk>,
+    mut latch: ResMut<ModalLatch>,
+    mono: Res<MonoFont>,
+    selected: Single<
+        (
+            Entity,
+            &mut TileMover,
+            &mut Transform,
+            &ChildOf,
+            &RecordingLibrary,
+        ),
+        With<Selected>,
+    >,
+    arena_roots: Query<(Entity, &Arena)>,
+    mut clocks: Query<&mut ArenaClock>,
+    mut current: ResMut<CurrentArena>,
+) -> Result {
+    let delta = pending.0;
+    commands.remove_resource::<PendingWalk>();
+    let (hero, mut mover, mut transform, child_of, library) = selected.into_inner();
+    let (_, arena) = arena_roots.get(child_of.parent())?;
+    let Some(entry) = adjacent_entry(arena.index(), mover.col, mover.row, delta) else {
+        return Ok(());
+    };
+    edge_walk(
+        &mut commands,
+        &mut latch,
+        &mono,
+        hero,
+        &mut mover,
+        &mut transform,
+        entry,
+        library,
+        &arena_roots,
+        &mut clocks,
+        &mut current,
+    )
+}
+
+/// Adds selected-hero movement + edge-walking to the intro scene.
+pub(crate) struct TravelPlugin;
+
+impl Plugin for TravelPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                // A live PendingWalk suppresses arrow movement for the one frame
+                // perform_pending_walk needs — otherwise both could move the hero
+                // in the same frame off a stale ChildOf.
+                move_selected.run_if(
+                    arrow_pressed
+                        .and(no_modal)
+                        .and(not_counting_down)
+                        .and(not(resource_exists::<PendingWalk>)),
+                ),
+                perform_pending_walk
+                    .run_if(resource_exists::<PendingWalk>.and(no_modal).and(is_idle)),
+            )
+                .run_if(in_state(AppState::Intro)),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edge_walks_enter_the_adjacent_arena_on_the_opposite_edge() {
+        // Guild House (1) → right past the last column → Sanctum (2), col 0.
+        assert_eq!(
+            adjacent_entry(1, MAX_COL, 15, IVec2::new(1, 0)),
+            Some((2, 0, 15))
+        );
+        // Guild House (1) → left past column 0 → Labyrinth (0), MAX_COL.
+        assert_eq!(
+            adjacent_entry(1, 0, 15, IVec2::new(-1, 0)),
+            Some((0, MAX_COL, 15))
+        );
+        // Bastion (4) → up past the top row → Guild House (1), row 0.
+        assert_eq!(
+            adjacent_entry(4, 30, MAX_ROW, IVec2::new(0, 1)),
+            Some((1, 30, 0))
+        );
+        // Guild House (1) → down past row 0 → Bastion (4), MAX_ROW.
+        assert_eq!(
+            adjacent_entry(1, 30, 0, IVec2::new(0, -1)),
+            Some((4, 30, MAX_ROW))
+        );
+    }
+
+    #[test]
+    fn the_outer_border_does_not_wrap() {
+        assert_eq!(adjacent_entry(0, 0, 15, IVec2::new(-1, 0)), None);
+        assert_eq!(adjacent_entry(1, 30, MAX_ROW, IVec2::new(0, 1)), None);
+        assert_eq!(adjacent_entry(8, MAX_COL, 15, IVec2::new(1, 0)), None);
+        assert_eq!(adjacent_entry(7, 30, 0, IVec2::new(0, -1)), None);
+    }
+
+    #[test]
+    fn steps_inside_the_arena_are_not_edge_walks() {
+        assert_eq!(adjacent_entry(4, 10, 10, IVec2::new(1, 0)), None);
+    }
+}

--- a/crates/arenic_game/src/ability.rs
+++ b/crates/arenic_game/src/ability.rs
@@ -29,14 +29,13 @@ pub struct AbilityBurst {
 /// via the stage's HDR + bloom). Centre it on the caster by spawning it as their
 /// child: `commands.spawn((holy_nova(..), ChildOf(caster)))`.
 pub fn holy_nova(
-    meshes: &mut Assets<Mesh>,
+    sphere: Handle<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     color: Color,
 ) -> impl Bundle + use<> {
     const START: f32 = 0.3;
     const BASE_ALPHA: f32 = 0.4;
     let l = color.to_linear();
-    let mesh = meshes.add(Sphere::new(1.0));
     let material = materials.add(StandardMaterial {
         base_color: color.with_alpha(BASE_ALPHA),
         emissive: LinearRgba::rgb(l.red, l.green, l.blue) * 5.0,
@@ -51,7 +50,7 @@ pub fn holy_nova(
             end_radius: 3.0,
             base_alpha: BASE_ALPHA,
         },
-        Mesh3d(mesh),
+        Mesh3d(sphere),
         MeshMaterial3d(material),
         Transform::from_scale(Vec3::splat(START)),
         NotShadowCaster,
@@ -100,6 +99,23 @@ pub fn play_sfx(commands: &mut Commands, sound: Handle<AudioSource>) {
     commands.spawn((AudioPlayer::new(sound), PlaybackSettings::DESPAWN));
 }
 
+/// Casts Holy Nova from `caster`: the burst VFX parented to them plus its sound.
+/// Shared by the GAME's live input (`1`) and ghost playback, so live take and
+/// replay can never drift. (The storybook assembles its own theme-tinted variant
+/// from [`holy_nova`] + [`play_sfx`] directly.)
+pub fn cast_holy_nova(
+    commands: &mut Commands,
+    meshes: &AbilityMeshes,
+    materials: &mut Assets<StandardMaterial>,
+    sfx: &AbilitySfx,
+    caster: Entity,
+) {
+    let holy_gold = Color::srgb(1.0, 0.9, 0.55);
+    let burst = holy_nova(meshes.sphere.clone(), materials, holy_gold);
+    commands.spawn((burst, ChildOf(caster)));
+    play_sfx(commands, sfx.holy_nova.clone());
+}
+
 /// Every ability's preloaded sound — one handle per ability (an ability is VFX +
 /// SFX). Loaded once at startup by [`AbilityPlugin`] so the first cast has no
 /// hitch; add a field here when you add an ability.
@@ -108,19 +124,30 @@ pub struct AbilitySfx {
     pub holy_nova: Handle<AudioSource>,
 }
 
-/// Preloads every ability's sound effect up front.
-fn load_sfx(mut commands: Commands, assets: Res<AssetServer>) {
+/// Shared ability meshes, built once at startup — every Holy Nova clones ONE
+/// unit-sphere handle instead of allocating a fresh mesh asset per cast (which
+/// would churn `Assets<Mesh>` forever under ghost playback).
+#[derive(Resource)]
+pub struct AbilityMeshes {
+    pub sphere: Handle<Mesh>,
+}
+
+/// Preloads every ability's sound effect + shared meshes up front.
+fn load_assets(mut commands: Commands, assets: Res<AssetServer>, mut meshes: ResMut<Assets<Mesh>>) {
     commands.insert_resource(AbilitySfx {
         holy_nova: assets.load("abilities/holy_nova.ogg"),
     });
+    commands.insert_resource(AbilityMeshes {
+        sphere: meshes.add(Sphere::new(1.0)),
+    });
 }
 
-/// Registers the ability-VFX systems and preloads [`AbilitySfx`].
+/// Registers the ability-VFX systems and preloads [`AbilitySfx`] + [`AbilityMeshes`].
 pub struct AbilityPlugin;
 
 impl Plugin for AbilityPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, load_sfx)
+        app.add_systems(Startup, load_assets)
             .add_systems(Update, update_ability_bursts);
     }
 }

--- a/crates/arenic_game/src/arena.rs
+++ b/crates/arenic_game/src/arena.rs
@@ -17,7 +17,10 @@ use crate::swarm::{Mote, SwarmMotion, SwarmSpec};
 use crate::theme::{ThemeId, Tint};
 
 /// One of the nine arenas (3×3 grid, row-major). The discriminant IS the grid index.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// Also a component: the game tags each arena root with its `Arena`, so systems can
+/// resolve an entity's arena (e.g. a hero's `ChildOf` parent) without a second id.
+#[derive(Component, Clone, Copy, PartialEq, Eq, Debug)]
+#[component(immutable)]
 pub enum Arena {
     Hunter,
     Guildmaster,

--- a/crates/arenic_game/src/grid.rs
+++ b/crates/arenic_game/src/grid.rs
@@ -62,13 +62,24 @@ impl TileMover {
         Self { col, row }
     }
 
-    /// Steps this mover by `delta` tiles, clamped to the arena grid, and snaps the
-    /// transform's local X/Y to the new tile centre (local Z is preserved). The ONE
-    /// place movement math lives — `strict_add` so a sim overflow fails loud
-    /// instead of silently wrapping (movement feeds the future record/replay).
+    /// Steps this mover by `delta` tiles, clamped to the arena grid. `strict_add`
+    /// so a sim overflow fails loud instead of silently wrapping (movement feeds
+    /// record/replay).
     pub fn step(&mut self, transform: &mut Transform, delta: IVec2) {
-        self.col = self.col.strict_add(delta.x).clamp(0, MAX_COL);
-        self.row = self.row.strict_add(delta.y).clamp(0, MAX_ROW);
+        self.snap_to(
+            transform,
+            self.col.strict_add(delta.x),
+            self.row.strict_add(delta.y),
+        );
+    }
+
+    /// Parks this mover on tile `(col, row)` (clamped to the arena) and snaps the
+    /// transform's local X/Y to its centre (local Z is preserved). The ONE place
+    /// tile-snapping math lives — stepping, ghost snapping, and edge-walking all
+    /// land here so the policy can never drift.
+    pub fn snap_to(&mut self, transform: &mut Transform, col: i32, row: i32) {
+        self.col = col.clamp(0, MAX_COL);
+        self.row = row.clamp(0, MAX_ROW);
         let p = tile_to_world(self.col, self.row);
         transform.translation.x = p.x;
         transform.translation.y = p.y;

--- a/crates/arenic_game/src/lib.rs
+++ b/crates/arenic_game/src/lib.rs
@@ -25,6 +25,7 @@ pub mod orbit;
 pub mod swarm;
 pub mod theme;
 pub mod tile;
+pub mod timeline;
 pub mod ui;
 
 pub use interaction::{InteractionPlugin, Interactive, UiFocus, hidden_outline};

--- a/crates/arenic_game/src/timeline.rs
+++ b/crates/arenic_game/src/timeline.rs
@@ -1,0 +1,324 @@
+//! Record & Replay timelines — the "sheet music" system (`_docs/RULEBOOK.md`).
+//!
+//! Every character can record a 2-minute stream of intent events per arena (its
+//! "staff" of sheet music, cached in its [`RecordingLibrary`]); committing folds
+//! the staff into the arena's single master [`ArenaTimeline`] (the "score"),
+//! which drives every folded [`Ghost`] as the arena's independent [`ArenaClock`]
+//! ticks. The sim runs on the fixed timestep and counts ticks, never seconds;
+//! events store *intent* (tile steps + ability slots) and transforms are derived
+//! on playback (`_docs/code-review.md` → Determinism).
+//!
+//! Pure timeline surgery lives in [`fold`] / [`unfold`] (unit-tested, no World).
+//! [`TimelinePlugin`] pins the fixed timestep to [`TICK_HZ`] and registers the
+//! per-tick playback systems; the binaries layer recording/input on top.
+
+use std::sync::Arc;
+
+use bevy::platform::collections::HashMap;
+use bevy::prelude::*;
+
+use crate::ability::{AbilityMeshes, AbilitySfx, cast_holy_nova};
+use crate::grid::TileMover;
+
+/// Sim ticks per second — the fixed-timestep rate everything below counts in.
+pub const TICKS_PER_SECOND: u32 = 60;
+/// [`TICKS_PER_SECOND`] as the rate [`TimelinePlugin`] pins `Time<Fixed>` to.
+pub const TICK_HZ: f64 = TICKS_PER_SECOND as f64;
+/// Ticks in one 2-minute arena cycle (const-evaluated: overflow fails the build).
+pub const CYCLE_TICKS: u32 = 120 * TICKS_PER_SECOND;
+/// Ticks in the 3-second pre-recording countdown.
+pub const COUNTDOWN_TICKS: u32 = 3 * TICKS_PER_SECOND;
+
+/// One recorded intent: what the player pressed, on which tick of the cycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TimelineEvent {
+    pub tick: u32,
+    pub action: Action,
+}
+
+/// A recordable intent — a tile step or an ability slot (`1..=4`). Slots 2-4 are
+/// recorded but are no-ops on playback today (only Holy Nova exists).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    Move(IVec2),
+    Ability(u8),
+}
+
+/// One character's committed staff for one arena: the tile it stood on at tick 0
+/// (`start` — every cycle replays from there) plus its tick-sorted events. A
+/// partial commit is simply a shorter event list; the ghost plays it, then idles.
+#[derive(Clone, Debug)]
+pub struct Recording {
+    pub start: IVec2,
+    pub events: Arc<[TimelineEvent]>,
+}
+
+/// A character's per-arena library of recordings, keyed by arena index — its
+/// staff per arena. Sim code only ever looks up by key; never iterate this for
+/// simulation (HashMap order is nondeterministic).
+#[derive(Component, Default)]
+pub struct RecordingLibrary(pub HashMap<u8, Recording>);
+
+/// Present while a character is folded into its arena's master timeline: playback
+/// drives it and direct input is ignored. `start` is the tile the ghost snaps to
+/// whenever its arena restarts at tick 0. Set once per fold (immutable) — a ghost
+/// changes by being unfolded and re-folded, never edited in place.
+#[derive(Component)]
+#[component(immutable)]
+pub struct Ghost {
+    pub start: IVec2,
+}
+
+/// One event of the master timeline: a [`TimelineEvent`] tagged with the ghost
+/// entity it drives.
+#[derive(Clone, Copy, Debug)]
+pub struct GhostEvent {
+    pub tick: u32,
+    pub ghost: Entity,
+    pub action: Action,
+}
+
+/// An arena's master timeline: every committed recording cloned, tagged with its
+/// ghost, and merged into one tick-sorted stream, plus the playback cursor.
+/// Sorting is stable for equal ticks (earlier-folded ghosts keep priority), so
+/// playback order is deterministic within a session.
+#[derive(Component, Default)]
+pub struct ArenaTimeline {
+    pub events: Vec<GhostEvent>,
+    pub cursor: usize,
+}
+
+/// An arena's independent 2-minute clock, in ticks (`0..CYCLE_TICKS`). Paused
+/// while a modal targets the arena or while a recording countdown holds it at 0.
+#[derive(Component, Default)]
+pub struct ArenaClock {
+    pub tick: u32,
+    pub paused: bool,
+}
+
+/// Replaces `ghost`'s events in the master timeline with `recording`'s and
+/// resets the cursor — folding always accompanies an arena restart (the caller
+/// zeroes the clock and snaps ghosts to their starts). Removing first makes
+/// re-committing idempotent; the stable sort keeps earlier-folded ghosts first
+/// within a tick.
+pub fn fold(timeline: &mut ArenaTimeline, ghost: Entity, recording: &Recording) {
+    timeline.events.retain(|e| e.ghost != ghost);
+    timeline.events.extend(
+        recording
+            .events
+            .iter()
+            .map(|&TimelineEvent { tick, action }| GhostEvent {
+                tick,
+                ghost,
+                action,
+            }),
+    );
+    timeline.events.sort_by_key(|e| e.tick);
+    timeline.cursor = 0;
+}
+
+/// Removes every event belonging to `ghost` and resyncs the cursor so playback
+/// continues seamlessly from `tick` (pass the arena clock's current tick). The
+/// arena does NOT restart — that's break-out semantics; restart paths overwrite
+/// the cursor anyway via [`restart`].
+pub fn unfold(timeline: &mut ArenaTimeline, ghost: Entity, tick: u32) {
+    timeline.events.retain(|e| e.ghost != ghost);
+    timeline.cursor = timeline.events.partition_point(|e| e.tick < tick);
+}
+
+/// Restarts an arena's playback: clock to tick 0, cursor to the top, unpaused.
+/// Callers also snap each of the arena's ghosts to its start ([`snap_ghost`]).
+pub fn restart(clock: &mut ArenaClock, timeline: &mut ArenaTimeline) {
+    clock.tick = 0;
+    clock.paused = false;
+    timeline.cursor = 0;
+}
+
+/// Parks a ghost on its recorded start tile (the pose every cycle replays from).
+pub fn snap_ghost(ghost: &Ghost, mover: &mut TileMover, transform: &mut Transform) {
+    mover.snap_to(transform, ghost.start.x, ghost.start.y);
+}
+
+/// The next clock value after one tick — wraps at the cycle boundary.
+fn advance(tick: u32) -> u32 {
+    tick.strict_add(1) % CYCLE_TICKS
+}
+
+/// The `FixedUpdate` playback phase — binaries order their recording systems
+/// `.after(TimelineSet)` so they observe this tick's clocks.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TimelineSet;
+
+/// Applies every master-timeline event whose tick has arrived: `Move` steps the
+/// ghost's [`TileMover`] (clamped — recorded moves never edge-walk) and
+/// `Ability(1)` casts Holy Nova from the ghost; slots 2-4 are no-ops for now.
+/// Runs before [`tick_clocks`], so an event plays exactly while `clock.tick`
+/// equals its recorded tick.
+fn play_timelines(
+    mut commands: Commands,
+    mut arenas: Query<(&ArenaClock, &mut ArenaTimeline)>,
+    mut ghosts: Query<(&mut TileMover, &mut Transform), With<Ghost>>,
+    meshes: Res<AbilityMeshes>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    sfx: Res<AbilitySfx>,
+) {
+    for (clock, mut timeline) in &mut arenas {
+        if clock.paused {
+            continue;
+        }
+        while let Some(&GhostEvent {
+            tick,
+            ghost,
+            action,
+        }) = timeline.events.get(timeline.cursor)
+        {
+            if tick > clock.tick {
+                break;
+            }
+            timeline.cursor = timeline.cursor.strict_add(1);
+            match action {
+                Action::Move(delta) => {
+                    if let Ok((mut mover, mut transform)) = ghosts.get_mut(ghost) {
+                        mover.step(&mut transform, delta);
+                    }
+                }
+                Action::Ability(1) => {
+                    cast_holy_nova(&mut commands, &meshes, &mut materials, &sfx, ghost);
+                }
+                Action::Ability(_) => {}
+            }
+        }
+    }
+}
+
+/// Advances every unpaused [`ArenaClock`] one tick; on wrap, rewinds playback
+/// and snaps the arena's ghosts back to their recorded starts.
+fn tick_clocks(
+    mut arenas: Query<(Entity, &mut ArenaClock, &mut ArenaTimeline)>,
+    mut ghosts: Query<(&Ghost, &ChildOf, &mut TileMover, &mut Transform)>,
+) {
+    for (arena, mut clock, mut timeline) in &mut arenas {
+        if clock.paused {
+            continue;
+        }
+        clock.tick = advance(clock.tick);
+        if clock.tick == 0 {
+            timeline.cursor = 0;
+            for (ghost, child_of, mut mover, mut transform) in &mut ghosts {
+                if child_of.parent() == arena {
+                    snap_ghost(ghost, &mut mover, &mut transform);
+                }
+            }
+        }
+    }
+}
+
+/// Pins the fixed timestep to [`TICK_HZ`] and drives every arena's clock +
+/// master-timeline playback. Add [`crate::ability::AbilityPlugin`] alongside it
+/// (playback casts need the preloaded [`AbilitySfx`]).
+pub struct TimelinePlugin;
+
+impl Plugin for TimelinePlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(Time::<Fixed>::from_hz(TICK_HZ))
+            .add_systems(
+                FixedUpdate,
+                (
+                    play_timelines.run_if(
+                        resource_exists::<AbilitySfx>.and(resource_exists::<AbilityMeshes>),
+                    ),
+                    tick_clocks,
+                )
+                    .chain()
+                    .in_set(TimelineSet),
+            );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(start: (i32, i32), ticks: &[u32]) -> Recording {
+        Recording {
+            start: IVec2::new(start.0, start.1),
+            events: ticks
+                .iter()
+                .map(|&tick| TimelineEvent {
+                    tick,
+                    action: Action::Move(IVec2::X),
+                })
+                .collect(),
+        }
+    }
+
+    fn two_ghosts() -> (Entity, Entity) {
+        let mut world = World::new();
+        (world.spawn_empty().id(), world.spawn_empty().id())
+    }
+
+    #[test]
+    fn fold_keeps_tick_order_and_is_stable_for_equal_ticks() {
+        let (a, b) = two_ghosts();
+        let mut tl = ArenaTimeline::default();
+        fold(&mut tl, a, &rec((0, 0), &[5, 10]));
+        fold(&mut tl, b, &rec((1, 1), &[5, 7]));
+        let ticks: Vec<u32> = tl.events.iter().map(|e| e.tick).collect();
+        assert_eq!(ticks, [5, 5, 7, 10]);
+        // Stable: at tick 5 the earlier-folded ghost keeps priority.
+        assert_eq!(tl.events[0].ghost, a);
+        assert_eq!(tl.events[1].ghost, b);
+    }
+
+    #[test]
+    fn refolding_the_same_ghost_is_idempotent() {
+        let (a, b) = two_ghosts();
+        let mut tl = ArenaTimeline::default();
+        let staff = rec((0, 0), &[5, 10]);
+        fold(&mut tl, a, &staff);
+        fold(&mut tl, b, &rec((1, 1), &[7]));
+        fold(&mut tl, a, &staff);
+        assert_eq!(tl.events.len(), 3);
+        assert_eq!(tl.events.iter().filter(|e| e.ghost == a).count(), 2);
+        assert_eq!(tl.cursor, 0);
+    }
+
+    #[test]
+    fn unfold_removes_exactly_one_ghost_and_resyncs_the_cursor() {
+        let (a, b) = two_ghosts();
+        let mut tl = ArenaTimeline::default();
+        fold(&mut tl, a, &rec((0, 0), &[5, 10]));
+        fold(&mut tl, b, &rec((1, 1), &[7]));
+        // Played through tick 8: events 5 and 7 already applied.
+        tl.cursor = 2;
+        unfold(&mut tl, a, 8);
+        assert_eq!(tl.events.len(), 1);
+        assert_eq!(tl.events[0].ghost, b);
+        // b's tick-7 event stays behind the cursor — playback continues, no replay.
+        assert_eq!(tl.cursor, 1);
+    }
+
+    #[test]
+    fn clock_wraps_to_zero_at_the_cycle_boundary() {
+        assert_eq!(advance(0), 1);
+        assert_eq!(advance(CYCLE_TICKS - 2), CYCLE_TICKS - 1);
+        assert_eq!(advance(CYCLE_TICKS - 1), 0);
+    }
+
+    #[test]
+    fn partial_recording_plays_through_then_idles() {
+        let (a, _) = two_ghosts();
+        let mut tl = ArenaTimeline::default();
+        fold(&mut tl, a, &rec((0, 0), &[0, 3]));
+        // Walk the cursor the way play_timelines does, far past the last event.
+        for tick in 0..10u32 {
+            while let Some(e) = tl.events.get(tl.cursor) {
+                if e.tick > tick {
+                    break;
+                }
+                tl.cursor = tl.cursor.strict_add(1);
+            }
+        }
+        assert_eq!(tl.cursor, tl.events.len());
+    }
+}

--- a/crates/arenic_storybook/src/abilities.rs
+++ b/crates/arenic_storybook/src/abilities.rs
@@ -3,7 +3,7 @@
 //! VFX itself is a reusable `arenic_game::ability` piece; the scene (player puck +
 //! target boss) is staged by [`crate::stage`].
 
-use arenic_game::ability::{AbilityPlugin, AbilitySfx, holy_nova, play_sfx};
+use arenic_game::ability::{AbilityMeshes, AbilityPlugin, AbilitySfx, holy_nova, play_sfx};
 use arenic_game::theme::ActiveTheme;
 use bevy::input::common_conditions::input_just_pressed;
 use bevy::prelude::*;
@@ -34,7 +34,7 @@ impl Plugin for AbilitiesPlugin {
 fn fire_holy_nova(
     mut commands: Commands,
     players: Query<Entity, With<Player>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    meshes: Res<AbilityMeshes>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     active: Res<ActiveTheme>,
     sfx: Res<AbilitySfx>,
@@ -43,7 +43,7 @@ fn fire_holy_nova(
     let color = active.palette().warning;
     let mut fired = false;
     for player in &players {
-        let burst = holy_nova(&mut meshes, &mut materials, color);
+        let burst = holy_nova(meshes.sphere.clone(), &mut materials, color);
         // Spawn as a child of the puck so it bursts from the player.
         commands.spawn((burst, ChildOf(player)));
         fired = true;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Introduce keyboard-first modal and recording systems, wire timeline simulation into the app, and update docs and tooling. Adds modal.rs (modal UI + input handling), integrates Timeline/Recording/Travel plugins in main, and registers arena master timelines and per-character recording libraries in the scene. Refactors intro_scene to gate world input during modals/countdowns, switch WASD → arrow-key input, and record ability events to the draft timeline; also makes selection component public and improves selection ring reparenting. Documentation (_docs/RULEBOOK.md, _docs/code-review.md) updated with recording/ modal UX, tick-based timeline details, and query/scheduling guidance. Tooling: Justfile adds fmt/check/test/doctest targets and expands the gate; .claude/settings.json adds a Stop hook to run the gate.